### PR TITLE
Add ability to customise events for table element

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ It is possible to override default behaviour just specify particular handler [Ev
 
 | Name | Type | Description |
 | --- | --- | --- |
-| cell | [<code>ChildAttributesItem</code>](#ChildAttributesItem) | Sets custom attributes for cell component |
+| cell | <code>[ChildAttributesItem](#ChildAttributesItem)<[ICellContentProps](#ICellContentProps)></code> | Sets custom attributes for cell element |
+| table | <code>[ChildAttributesItem](#ChildAttributesItem)<[Table](#Table)></code> | Sets custom attributes for table element |
 
 
 <a name="ChildAttributesItem"></a>
@@ -197,7 +198,7 @@ A second parameter in each [react Synthetic Event](https://reactjs.org/docs/even
 | --- | --- | --- |
 | baseFunc | <code>any</code> | Contains default function for overrided function - it is easy to add additional logic and execute default behaviour where you want it |
 | childElementAttributes | <code>HTMLAttributes&lt;HTMLElement&gt;</code> | Default HTMLAttributes of the component |
-| childProps | <code>ChildProps</code> | Props of the component |
+| childProps | <code>any</code> | Props of the component |
 | dispatch | <code>(type: string, data: any) => void</code> | Executes specific action with specific data |
 
 <a name="Group"></a>

--- a/README.md
+++ b/README.md
@@ -148,17 +148,17 @@ Describes column of table its look and behaviour
 | dataType | [<code>DataType</code>](#DataType) | Specifies the type of column |
 | editor | [<code>EditorFunc</code>](#EditorFunc) | Returns an editor if cell is in editable mode [Custom Editor Example](https://komarovalexander.github.io/ka-table/#/custom-editor) |
 | filterRowCell | [<code>FilterRowFunc</code>](#FilterRowFunc) | Returns an editor for filter row cell [Filter Row Custom Editor](https://komarovalexander.github.io/ka-table/#/filter-row-custom-editor) |
-| filterRowOperator | string | Sets filter row operator [Filter Row Custom Editor](https://komarovalexander.github.io/ka-table/#/filter-row-custom-editor). See the list of predefined filter operators [<code>FilterOperatorName</code>](#FilterOperatorName) |
-| filterRowValue | any | Sets filter row value [Filter Row](https://komarovalexander.github.io/ka-table/#/filter-row) |
-| field | string | Specifies the property of data's object which value will be used in column, if null value from key option will be used |
+| filterRowOperator | <code>string</code> | Sets filter row operator [Filter Row Custom Editor](https://komarovalexander.github.io/ka-table/#/filter-row-custom-editor). See the list of predefined filter operators [<code>FilterOperatorName</code>](#FilterOperatorName) |
+| filterRowValue | <code>any</code> | Sets filter row value [Filter Row](https://komarovalexander.github.io/ka-table/#/filter-row) |
+| field | <code>string</code> | Specifies the property of data's object which value will be used in column, if null value from key option will be used |
 | format | [<code>FormatFunc</code>](#FormatFunc) | Returns formated cell string [Example](https://komarovalexander.github.io/ka-table/#/custom-cell) |
-| headCell | HeaderCellFunc | Returns a custom header cell [Custom Head Cell Example](https://komarovalexander.github.io/ka-table/#/custom-header-cell) |
-| isEditable | boolean | Specifies can column be editable or not |
-| key | string | Mandatory field, specifies unique key for the column |
+| headCell | <code>HeaderCellFunc</code> | Returns a custom header cell [Custom Head Cell Example](https://komarovalexander.github.io/ka-table/#/custom-header-cell) |
+| isEditable | <code>boolean</code> | Specifies can column be editable or not |
+| key | <code>string</code> | Mandatory field, specifies unique key for the column |
 | search | [<code>SearchFunc</code>](#SearchFunc) | Overrides the default search method for the cell. Executes if [Table.search](#Table.search) option is set |
 | sortDirection | [<code>SortDirection</code>](#SortDirection) | Sets the direction of sorting for the column |
-| style | React.CSSProperties | Sets the style options of the elements |
-| title | string | Specifies the text of the header |
+| style | <code>React.CSSProperties</code> | Sets the style options of the elements |
+| title | <code>string</code> | Specifies the text of the header |
 | validation | [<code>ValidationFunc</code>](#ValidationFunc) | Returns the validation error string or does not return anything in case of passed validation [Validation Example](https://komarovalexander.github.io/ka-table/#/validation) |
 
 
@@ -171,8 +171,8 @@ Describes the position of a cell in  the table
 
 | Name | Type | Description |
 | --- | --- | --- |
-| field | string | The field of specific column |
-| rowKeyValue | any | Data's key value of every specific row |
+| field | <code>string</code> | The field of specific column |
+| rowKeyValue | <code>any</code> | Data's key value of every specific row |
 
 
 <a name="ChildAttributes"></a>
@@ -182,7 +182,7 @@ It is possible to override default behaviour just specify particular handler [Ev
 
 | Name | Type | Description |
 | --- | --- | --- |
-| cell | [ChildAttributesItem](#ChildAttributesItem) | Sets custom attributes for cell component |
+| cell | [<code>ChildAttributesItem</code>](#ChildAttributesItem) | Sets custom attributes for cell component |
 
 
 <a name="ChildAttributesItem"></a>
@@ -195,10 +195,10 @@ A second parameter in each [react Synthetic Event](https://reactjs.org/docs/even
 
 | Name | Type | Description |
 | --- | --- | --- |
-| baseFunc | any | Contains default function for overrided function - it is easy to add additional logic and execute default behaviour where you want it |
-| childElementAttributes | HTMLAttributes< HTMLElement > | Default HTMLAttributes of the component |
-| childProps | ChildProps | Props of the component |
-| dispatch | (type: string, data: any) => void | Executes specific action with specific data |
+| baseFunc | <code>any</code> | Contains default function for overrided function - it is easy to add additional logic and execute default behaviour where you want it |
+| childElementAttributes | <code>HTMLAttributes&lt;HTMLElement&gt;</code> | Default HTMLAttributes of the component |
+| childProps | <code>ChildProps</code> | Props of the component |
+| dispatch | <code>(type: string, data: any) => void</code> | Executes specific action with specific data |
 
 <a name="Group"></a>
 ### Group
@@ -207,7 +207,7 @@ A second parameter in each [react Synthetic Event](https://reactjs.org/docs/even
 
 | Name | Type | Description |
 | --- | --- | --- |
-| field | string | The grouped column's field |
+| field | <code>string</code> | The grouped column's field |
 
 
 <a name="VirtualScrolling"></a>
@@ -217,9 +217,9 @@ A second parameter in each [react Synthetic Event](https://reactjs.org/docs/even
 
 | Name | Type | Description |
 | --- | --- | --- |
-| scrollPosition | number | Current scroll top position |
-| itemHeight | ((data: any) => number) \| number | Returns height of specific row |
-| tbodyHeight | number | tbody height |
+| scrollPosition | <code>number</code> | Current scroll top position |
+| itemHeight | <code>((data: any) => number)</code> \| <code>number</code> | Returns height of specific row |
+| tbodyHeight | <code>number</code> | tbody height |
 
 
 <a name="DataType"></a>
@@ -343,11 +343,11 @@ Function which obtains value of specific cell and row - as parameters and return
 | Name | Type | Description |
 | --- | --- | --- |
 | column | [<code>Column</code>](#Column) | column of the editor |
-| dispatch | (type: string, data: any) => void | can forse Table make change in data, close the editor, and other actions |
-| field | string | field name of current column |
-| rowData | any | data of the row in which editor is shown |
-| isSelectedRow | boolean | selection state of the current row |
-| rowKeyField | string | field which is used to identify row |
+| dispatch | <code>(type: string, data: any) => void</code> | can forse Table make change in data, close the editor, and other actions |
+| field | <code>string</code> | field name of current column |
+| rowData | <code>any</code> | data of the row in which editor is shown |
+| isSelectedRow | <code>boolean</code> | selection state of the current row |
+| rowKeyField | <code>string</code> | field which is used to identify row |
 
 <a name="IFilterRowEditorProps"></a>
 ### IFilterRowEditorProps
@@ -356,7 +356,7 @@ Function which obtains value of specific cell and row - as parameters and return
 | Name | Type | Description |
 | --- | --- | --- |
 | column | [<code>Column</code>](#Column) | column of the editor |
-| dispatch | (type: string, data: any) => void |  can forse Table make change in filter data and other actions  |
+| dispatch | <code>(type: string, data: any) => void</code> |  can forse Table make change in filter data and other actions  |
 
 
 <a name="ICellContentProps"></a>
@@ -366,8 +366,8 @@ Function which obtains value of specific cell and row - as parameters and return
 | Name | Type | Description |
 | --- | --- | --- |
 | column | [<code>Column</code>](#Column) | settings of the column in which editor is shown |
-| openEditor | () => void | call this method to open editor of the cell |
-| rowData | any | data of the row in which editor is shown |
+| openEditor | <code>() => void</code> | call this method to open editor of the cell |
+| rowData | <code>any</code> | data of the row in which editor is shown |
 
 
 <a name="IDataRowProps"></a>
@@ -377,10 +377,10 @@ Function which obtains value of specific cell and row - as parameters and return
 | Name | Type | Description |
 | --- | --- | --- |
 | columns | [<code>Column[]</code>](#Column) | Columns in table and their look and behaviour |
-| dispatch | (type: string, data: any) => void | Executes specific action with specific data |
+| dispatch | <code>(type: string, data: any) => void</code> | Executes specific action with specific data |
 | editableCells | [<code>Cell[]</code>](#Cell) | Array of cells that are in edit mode |
 | editingMode | [<code>EditingMode</code>](#EditingMode) | Table's editing mode |
-| rowData | any | Data of current row |
-| isSelectedRow | boolean | Describes selected state of current row |
-| rowKeyField | string | Data's field which is used to identify row |
-| selectedRows | any[] | Array of rows keys which are marked as selected |
+| rowData | <code>any</code> | Data of current row |
+| isSelectedRow | <code>boolean</code> | Describes selected state of current row |
+| rowKeyField | <code>string</code> | Data's field which is used to identify row |
+| selectedRows | <code>any[]</code> | Array of rows keys which are marked as selected |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ export default SortingDemo;
 | Name | Type | Description |
 | --- | --- | --- |
 | columns | [<code>Column[]</code>](#Column) | Columns in table and their look and behaviour |
+| childAttributes | <code>[ChildAttributes](#ChildAttributes)</code> | Object describes attributes for data grid child components [Events Demo](https://komarovalexander.github.io/ka-table/#/events) |
 | data | <code>any\[\]</code> | The Table's data |
 | dataRow | [<code>DataRowFunc</code>](#DataRowFunc) | Returns Data Row Template [Custom Data Row Example](https://komarovalexander.github.io/ka-table/#/custom-data-row |
 | editableCells | [<code>Cell[]</code>](#Cell) | Array of cells that are in edit mode [Editing Example](https://komarovalexander.github.io/ka-table/#/editing) |
@@ -172,6 +173,32 @@ Describes the position of a cell in  the table
 | --- | --- | --- |
 | field | string | The field of specific column |
 | rowKeyValue | any | Data's key value of every specific row |
+
+
+<a name="ChildAttributes"></a>
+### ChildAttributes
+Describes the attributes for a specific child component
+It is possible to override default behaviour just specify particular handler [Events Demo](https://komarovalexander.github.io/ka-table/#/events)
+
+| Name | Type | Description |
+| --- | --- | --- |
+| cell | [ChildAttributesItem](#ChildAttributesItem) | Sets custom attributes for cell component |
+
+
+<a name="ChildAttributesItem"></a>
+#### ChildAttributesItem
+This object is an extension for React HTMLAttributes. It contains all attributes and all [react Synthetic Events](https://reactjs.org/docs/events.html), but in each event it adds a second parameter which contains additional data with [AttributeTableData type](#AttributeTableData).
+
+<a name="AttributeTableData"></a>
+#### AttributeTableData
+A second parameter in each [react Synthetic Event](https://reactjs.org/docs/events.html). Contains component-related information.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| baseFunc | any | Contains default function for overrided function - it is easy to add additional logic and execute default behaviour where you want it |
+| childElementAttributes | HTMLAttributes< HTMLElement > | Default HTMLAttributes of the component |
+| childProps | ChildProps | Props of the component |
+| dispatch | (type: string, data: any) => void | Executes specific action with specific data |
 
 <a name="Group"></a>
 ### Group

--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ export default SortingDemo;
 | editingMode | [<code>EditingMode</code>](#EditingMode) | Sets the table's editing mode [Editing Example](https://komarovalexander.github.io/ka-table/#/editing) |
 | filterRow | [<code>FilteringMode</code>](#FilteringMode) | Show filtering related UI elements in Table [Filter Row Example](https://komarovalexander.github.io/ka-table/#/filter-row) |
 | groups | [<code>Group[]</code>](#Group) | Group's in the table [Grouping Example](https://komarovalexander.github.io/ka-table/#/grouping) |
-| onDataChange | (data: any[]) => void | This function is called each time when data going to change, use it to override current data [Editing Example](https://komarovalexander.github.io/ka-table/#/editing) |
-| onOptionChange | (value: any) => void | This is mandatory function, this executes each time when grid going to change its state, use it to override current state [Example](https://komarovalexander.github.io/ka-table/#/editing) |
-| onEvent | (type: string, data: any) => void | Executes each time when dispatch is called [Events](https://komarovalexander.github.io/ka-table/#/events) |
-| groupsExpanded | any[][] | Groups that are expanded in the grid |
-| rowKeyField | string | Data's field which is used to identify row |
-| search <a name="Table.search"></a> | string | Specifies the text which are used for search by data [Search Example](https://komarovalexander.github.io/ka-table/#/search) |
-| selectedRows | any[] | Array of rows keys which are marked as selected [Selection Example](https://komarovalexander.github.io/ka-table/#/selection) |
+| onDataChange | <code>(data: any[]) => void</code> | This function is called each time when data going to change, use it to override current data [Editing Example](https://komarovalexander.github.io/ka-table/#/editing) |
+| onOptionChange | <code>(value: any) => void</code> | This is mandatory function, this executes each time when grid going to change its state, use it to override current state [Example](https://komarovalexander.github.io/ka-table/#/editing) |
+| onEvent | <code>(type: string, data: any) => void</code> | Executes each time when dispatch is called [Events](https://komarovalexander.github.io/ka-table/#/events) |
+| groupsExpanded | <code>any[][]</code> | Groups that are expanded in the grid |
+| rowKeyField | <code>string</code> | Data's field which is used to identify row |
+| search <a name="Table.search"></a> | <code>string</code> | Specifies the text which are used for search by data [Search Example](https://komarovalexander.github.io/ka-table/#/search) |
+| selectedRows | <code>any[]</code> | Array of rows keys which are marked as selected [Selection Example](https://komarovalexander.github.io/ka-table/#/selection) |
 | sortingMode | [<code>SortingMode</code>](#SortingMode)  | Sorting mode [Sorting Example](https://komarovalexander.github.io/ka-table/#/sorting) |
 | virtualScrolling | [<code>VirtualScrolling</code>](#VirtualScrolling) | Virtual scrolling options - set it as empty object {} to enable virtual scrolling and auto calculate its parameters [Many Rows Example](https://komarovalexander.github.io/ka-table/#/many-rows) |
 
@@ -187,7 +187,7 @@ It is possible to override default behaviour just specify particular handler [Ev
 
 <a name="ChildAttributesItem"></a>
 #### ChildAttributesItem
-This object is an extension for React HTMLAttributes. It contains all attributes and all [react Synthetic Events](https://reactjs.org/docs/events.html), but in each event it adds a second parameter which contains additional data with [AttributeTableData type](#AttributeTableData).
+This object is an extension for React HTMLAttributes. It contains all attributes and all [react Synthetic Events](https://reactjs.org/docs/events.html), but in each event it adds a second parameter which contains additional data with <code>[AttributeTableData type](#AttributeTableData)</code>.
 
 <a name="AttributeTableData"></a>
 #### AttributeTableData
@@ -287,35 +287,35 @@ A second parameter in each [react Synthetic Event](https://reactjs.org/docs/even
 <a name="CellFunc"></a>
 ### CellFunc
 
-(props: [<code>ICellContentProps</code>](#ICellContentProps)) => any;
+<code>(props: [ICellContentProps](#ICellContentProps)) => any;</code>
 
 Function which obtains [<code>ICellContentProps</code>](#ICellContentProps) as parameter and returns React component which should be shown instead of cell content.
 
 <a name="DataRowFunc"></a>
 ### DataRowFunc
 
-(props: [<code>IDataRowProps</code>](#IDataRowProps)) => any;
+<code>(props: [IDataRowProps](#IDataRowProps)) => any;</code>
 
 Function which obtains [<code>IDataRowProps</code>](#IDataRowProps) as parameter and returns React component which should be shown instead of Row content.
 
 <a name="EditorFunc"></a>
 ### EditorFunc
 
-(props: [<code>ICellEditorProps</code>](#ICellEditorProps)) => any;
+<code>(props: [ICellEditorProps](#ICellEditorProps)) => any;</code>
 
 Function which obtains [<code>ICellEditorProps</code>](#ICellEditorProps) as parameter and returns React component which should be shown instead of default editor.
 
 <a name="FilterRowFunc"></a>
 ### FilterRowFunc
 
-(props: [<code>IFilterRowEditorProps</code>](#IFilterRowEditorProps)) => any;
+<code>(props: [IFilterRowEditorProps](#IFilterRowEditorProps)) => any;</code>
 
 Function which obtains [<code>IFilterRowEditorProps</code>](#IFilterRowEditorProps) as parameter and returns React component which should be shown instead of default filter row's editor.
 
 <a name="FormatFunc"></a>
 ### FormatFunc
 
-(value: any) => any;
+<code>(value: any) => any;</code>
 
 Function which obtains value as parameter and returns formated value which will be shown in cell.
 
@@ -323,15 +323,15 @@ Function which obtains value as parameter and returns formated value which will 
 <a name="SearchFunc"></a>
 ### SearchFunc
 
-(searchText?: string, rowData?: any, column?: Column) => boolean;
+<code>(searchText?: string, rowData?: any, column?: Column) => boolean;</code>
 
-Function which obtains searchText?: string, rowData?: any, column?: Column - as parameters and returns boolean value which is true if cell's value is matched with searched value and false otherwise.
+Function which obtains <code>searchText?: string, rowData?: any, column?: Column</code> - as parameters and returns <code>boolean</code> value which is true if cell's value is matched with searched value and false otherwise.
 
 
 <a name="ValidationFunc"></a>
 ### ValidationFunc
 
-(value: any, rowData: any) => string | void;
+<code>(value: any, rowData: any) => string | void;</code>
 
 Function which obtains value of specific cell and row - as parameters and returns validation error string or does not return anything in case of passed validation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "2.2.4",
+  "version": "2.3.1",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/command-column",

--- a/src/Demos/CustomEditorDemo/CustomEditorDemo.scss
+++ b/src/Demos/CustomEditorDemo/CustomEditorDemo.scss
@@ -1,0 +1,31 @@
+.custom-editor-demo-table{
+  td{
+    height: 40px;
+  }
+}
+.custom-editor{
+  white-space: nowrap;
+  overflow: hidden;
+  .custom-editor-button{
+    margin-left: 5px;
+    outline: none;
+    cursor: pointer;
+    border: none;
+    margin-left: 10px;
+    &.custom-editor-button-save{
+      background-color: #4285F4;
+      border-radius: 5px;
+      color: #FFFFFF;
+      padding: 10px 15px;
+    }
+    &.custom-editor-button-cancel{
+      background: none;
+      font-weight: 500;
+      padding: 10px 5px;
+    }
+  }
+  input{
+    border: 1px solid #CBDCE4;
+    padding: 10px 15px;
+  }
+}

--- a/src/Demos/CustomEditorDemo/CustomEditorDemo.tsx
+++ b/src/Demos/CustomEditorDemo/CustomEditorDemo.tsx
@@ -1,3 +1,5 @@
+import './CustomEditorDemo.scss';
+
 import React, { useState } from 'react';
 
 import { ITableOption, Table } from '../../lib';
@@ -24,18 +26,18 @@ const CustomEditor: React.FC<EditorFuncPropsWithChildren> = ({
   };
   const [value, setValue] = useState(rowData[key]);
   return (
-    <div>
-    <input
-      className='form-control'
-      type='text'
-      value={value}
-      onChange={(event) => setValue(event.currentTarget.value)}/>
-    <button onClick={() => {
-      const newValue = { ...rowData, ...{ [key]: value } };
-      dispatch(ActionType.ChangeRowData, { newValue });
-      close();
-    }}>Save</button>
-    <button onClick={close}>Cancel</button>
+    <div className='custom-editor'>
+      <input
+        className='form-control'
+        type='text'
+        value={value}
+        onChange={(event) => setValue(event.currentTarget.value)}/>
+      <button className='custom-editor-button custom-editor-button-save' onClick={() => {
+        const newValue = { ...rowData, ...{ [key]: value } };
+        dispatch(ActionType.ChangeRowData, { newValue });
+        close();
+      }}>Save</button>
+      <button className='custom-editor-button custom-editor-button-cancel' onClick={close}>Cancel</button>
     </div>
   );
 };
@@ -71,13 +73,13 @@ const CustomLookupEditor: React.FC<EditorFuncPropsWithChildren> = ({
 
 const tableOption: ITableOption = {
   columns: [
-    { dataType: DataType.String, key: 'name', title: 'Name', editor: CustomEditor, style: { width: '30%' } },
-    { key: 'score', title: 'Score', dataType: DataType.Number, style: { width: '10%' } },
+    { dataType: DataType.String, key: 'name', title: 'Name', editor: CustomEditor, style: { width: '330px' } },
+    { key: 'score', title: 'Score', dataType: DataType.Number, style: { width: '50px' } },
     {
       dataType: DataType.Boolean,
       editor: CustomLookupEditor,
       key: 'passed',
-      style: { width: '10%' },
+      style: { width: '50px' },
       title: 'Passed',
     },
     {
@@ -87,6 +89,7 @@ const tableOption: ITableOption = {
       title: 'Next Try',
     },
   ],
+  editableCells: [{ columnKey: 'name', rowKey: 1 }],
   editingMode: EditingMode.Cell,
   rowKeyField: 'id',
 };
@@ -107,6 +110,7 @@ const CustomEditorDemo: React.FC = () => {
       data={data}
       onOptionChange={onOptionChange}
       onDataChange={onDataChange}
+      childAttributes={{table: {className: 'custom-editor-demo-table'} }}
     />
   );
 };

--- a/src/Demos/EventsDemo/EventsDemo.tsx
+++ b/src/Demos/EventsDemo/EventsDemo.tsx
@@ -34,7 +34,7 @@ const tableOption: ITableOption = {
 const childAttributes: ChildAttributes = {
   cell: {
     className: 'my-cell-class',
-    onClick: (e, extendedEvent): any => {
+    onClick: (e, extendedEvent) => {
       const { childProps: { dispatch } } = extendedEvent;
       dispatch('MY_CELL_onClick', { extendedEvent });
     },
@@ -45,6 +45,12 @@ const childAttributes: ChildAttributes = {
       const { dispatch, childElementAttributes } = extendedEvent;
       dispatch('MY_CELL_onDoubleClick', { extendedEvent });
       childElementAttributes.onClick!(e);
+    },
+  },
+  table: {
+    onMouseEnter: (e, extendedEvent) => {
+      const { dispatch } = extendedEvent;
+      dispatch('MY_TABLE_onMouseEnter', { extendedEvent });
     },
   },
 };

--- a/src/lib/Components/CellComponent/CellComponent.test.tsx
+++ b/src/lib/Components/CellComponent/CellComponent.test.tsx
@@ -3,23 +3,26 @@ import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { DataType } from '../../enums';
-import CellComponent from './CellComponent';
+import { DataType, EditingMode } from '../../enums';
+import CellComponent, { ICellComponentProps } from './CellComponent';
 
 Enzyme.configure({ adapter: new Adapter() });
-const props: any = {
+
+const props: ICellComponentProps = {
+  childAttributes: {},
   column: {
     dataType: DataType.String,
-    field: 'columnField',
+    key: 'columnField',
     title: 'Field',
   },
-  editableCells: [],
+  dispatch: () => {},
+  editingMode: EditingMode.None,
   isEditableCell: false,
-  onOptionChange: () => {},
+  isSelectedRow: false,
   rowData: {
     column: 1,
   },
-  rowKey: '1',
+  rowKeyField: '1',
 };
 
 it('renders without crashing', () => {

--- a/src/lib/Components/CellComponent/CellComponent.tsx
+++ b/src/lib/Components/CellComponent/CellComponent.tsx
@@ -10,7 +10,7 @@ import CellContent from '../CellContent/CellContent';
 import CellEditor from '../CellEditor/CellEditor';
 
 export interface ICellComponentProps {
-  childAttributes?: ChildAttributes;
+  childAttributes: ChildAttributes;
   column: Column;
   dispatch: DispatchFunc;
   editingMode: EditingMode;

--- a/src/lib/Components/CellContent/CellContent.test.tsx
+++ b/src/lib/Components/CellContent/CellContent.test.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { DataType } from '../../enums';
+import { DataType, EditingMode } from '../../enums';
 import CellContent, { ICellContentProps } from './CellContent';
 
 const props: ICellContentProps = {
+  childAttributes: {},
   column: {
     dataType: DataType.String,
     key: 'columnField',
     title: 'Field',
   },
   dispatch: () => {},
+  editingMode: EditingMode.None,
+  field: 'columnField',
   rowData: { column : 1 },
   rowKeyField: '',
 };

--- a/src/lib/Components/CellContent/CellContent.tsx
+++ b/src/lib/Components/CellContent/CellContent.tsx
@@ -6,7 +6,7 @@ import { DispatchFunc } from '../../types';
 import CellText from '../CellText/CellText';
 
 export interface ICellContentProps {
-  childAttributes?: ChildAttributes;
+  childAttributes: ChildAttributes;
   column: Column;
   dispatch: DispatchFunc;
   editingMode: EditingMode;

--- a/src/lib/Components/CellText/CellText.test.tsx
+++ b/src/lib/Components/CellText/CellText.test.tsx
@@ -11,6 +11,7 @@ import CellText from './CellText';
 Enzyme.configure({ adapter: new Adapter() });
 
 const props: ICellContentProps = {
+  childAttributes: {},
   column: {
     dataType: DataType.String,
     key: 'columnField',

--- a/src/lib/Components/CellText/CellText.test.tsx
+++ b/src/lib/Components/CellText/CellText.test.tsx
@@ -24,6 +24,8 @@ const props: ICellContentProps = {
   rowKeyField: 'id',
 };
 
+afterEach(() => jest.clearAllMocks());
+
 describe('CellText', () => {
   it('renders without crashing', () => {
     const element = document.createElement('td');
@@ -40,5 +42,11 @@ describe('CellText', () => {
     expect(props.dispatch).toBeCalledWith(
       ActionType.OpenEditor, { cell },
     );
+  });
+
+  it('should skip OpenEditor', () => {
+    const wrapper = mount(<CellText {...props} editingMode={EditingMode.None} />);
+    wrapper.find('.ka-cell-text').simulate('click');
+    expect(props.dispatch).toBeCalledTimes(0);
   });
 });

--- a/src/lib/Components/CellText/CellText.tsx
+++ b/src/lib/Components/CellText/CellText.tsx
@@ -4,7 +4,7 @@ import { ActionType, EditingMode } from '../../enums';
 import { Cell } from '../../models';
 import { getField } from '../../Utils/ColumnUtils';
 import { isEmpty } from '../../Utils/CommonUtils';
-import { mergeProps } from '../../Utils/PropsUtils';
+import { extendProps } from '../../Utils/PropsUtils';
 import { ICellContentProps } from '../CellContent/CellContent';
 
 const CellText: React.FunctionComponent<ICellContentProps> = (props) => {
@@ -32,10 +32,7 @@ const CellText: React.FunctionComponent<ICellContentProps> = (props) => {
     },
   };
 
-  let divProps = componentProps;
-  if (childAttributes && childAttributes.cell) {
-    divProps = mergeProps(componentProps, props, childAttributes.cell);
-  }
+  const divProps = extendProps(componentProps, props, childAttributes.cell, props.dispatch);
   return (
     <div {...divProps}>{formatedValue || <>&nbsp;</>}</div>
   );

--- a/src/lib/Components/DataRow/DataRow.test.tsx
+++ b/src/lib/Components/DataRow/DataRow.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { DataType } from '../../enums';
-import DataRow from './DataRow';
+import { DataType, EditingMode } from '../../enums';
+import DataRow, { IRowProps } from './DataRow';
 
-const props: any = {
+const props: IRowProps = {
+  childAttributes: {},
   columns: [
     { key: 'column', title: 'Column 1', dataType: DataType.String },
     { key: 'column2', title: 'Column 2', dataType: DataType.String },
   ],
+  dispatch: () => {},
+  editableCells: [],
+  editingMode: EditingMode.None,
+  groupColumnsCount: 0,
   rowData: [{ column: 1, column2: 2 }],
-  rowKey: 'column',
+  rowKeyField: 'column',
+  selectedRows: [],
 };
 
 it('renders without crashing', () => {

--- a/src/lib/Components/DataRow/DataRow.tsx
+++ b/src/lib/Components/DataRow/DataRow.tsx
@@ -10,7 +10,7 @@ import DataRowContent from '../DataRowContent/DataRowContent';
 import EmptyCells from '../EmptyCells/EmptyCells';
 
 export interface IRowCommonProps {
-  childAttributes?: ChildAttributes;
+  childAttributes: ChildAttributes;
   columns: Column[];
   dispatch: DispatchFunc;
   editableCells: Cell[];

--- a/src/lib/Components/DataRow/DataRow.tsx
+++ b/src/lib/Components/DataRow/DataRow.tsx
@@ -32,7 +32,7 @@ const DataRow: React.FunctionComponent<IRowProps> = (props) => {
     rowData,
     rowKeyField,
     dataRow,
-    selectedRows = [],
+    selectedRows,
     trRef,
   } = props;
   const rowKeyValue = rowData[rowKeyField];

--- a/src/lib/Components/DataRowContent/DataRowContent.test.tsx
+++ b/src/lib/Components/DataRowContent/DataRowContent.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { DataType } from '../../enums';
-import DataRowContent from './DataRowContent';
+import { DataType, EditingMode } from '../../enums';
+import DataRowContent, { IDataRowProps } from './DataRowContent';
 
-const props: any = {
+const props: IDataRowProps = {
+  childAttributes: {},
   columns: [
     { key: 'column', title: 'Column 1', dataType: DataType.String },
     { key: 'column2', title: 'Column 2', dataType: DataType.String },
   ],
+  dispatch: () => {},
+  editableCells: [],
+  editingMode: EditingMode.None,
+  isSelectedRow: false,
   rowData: [{ column: 1, column2: 2 }],
-  rowKey: 'column',
+  rowKeyField: 'column',
+  selectedRows: [],
 };
 
 it('renders without crashing', () => {

--- a/src/lib/Components/Table/Table.tsx
+++ b/src/lib/Components/Table/Table.tsx
@@ -10,6 +10,7 @@ import { VirtualScrolling } from '../../Models/VirtualScrolling';
 import { DataChangeFunc, DataRowFunc, EventFunc, OptionChangeFunc } from '../../types';
 import { wrapDispatch } from '../../Utils/ActionUtils';
 import { filterData, searchData } from '../../Utils/FilterUtils';
+import { extendProps } from '../../Utils/PropsUtils';
 import { sortData } from '../../Utils/SortUtils';
 import { convertToColumnTypes } from '../../Utils/TypeUtils';
 import FilterRow from '../FilterRow/FilterRow';
@@ -51,6 +52,7 @@ export interface ITableAllProps extends ITableEvents, ITableOption {
 
 export const Table: React.FunctionComponent<ITableAllProps> = (props) => {
   const {
+    childAttributes = {},
     editableCells = [],
     editingMode = EditingMode.None,
     filteringMode,
@@ -75,9 +77,14 @@ export const Table: React.FunctionComponent<ITableAllProps> = (props) => {
 
   const dispatch = wrapDispatch(props);
 
+  const componentProps: React.HTMLAttributes<HTMLTableElement> = {
+    className: defaultOptions.css.table,
+  };
+
+  const tableProps = extendProps(componentProps, props, childAttributes.table, dispatch);
   return (
     <div className='ka' >
-      <table className={defaultOptions.css.table}>
+      <table {...tableProps}>
         <thead className={defaultOptions.css.thead}>
           <HeadRow
             groupColumnsCount={groupColumnsCount}
@@ -97,6 +104,7 @@ export const Table: React.FunctionComponent<ITableAllProps> = (props) => {
         <TableBody
             {...props}
             columns={columns}
+            childAttributes={childAttributes}
             data={data}
             editableCells={editableCells}
             editingMode={editingMode}

--- a/src/lib/Components/TableBody/TableBody.test.tsx
+++ b/src/lib/Components/TableBody/TableBody.test.tsx
@@ -1,18 +1,27 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { EditingMode } from '../../enums';
 import TableBody from './TableBody';
 
 const tableProps: any = {
+  childAttributes: {},
   columns: [
-    { key: 'column', name: 'Column 1' },
-    { key: 'column2', name: 'Column 2' },
+    { key: 'column', title: 'Column 1' },
+    { key: 'column2', title: 'Column 2' },
   ],
   data: [
     { column: 1, column2: 2, id: 1 },
     { column: 12, column2: 22, id: 2 },
   ],
+  dispatch: () => {},
+  editableCells: [],
+  editingMode: EditingMode.None,
+  groupColumnsCount: 0,
+  groupedColumns: [],
+  onOptionChange: () => {},
   rowKeyField: 'id',
+  selectedRows: [],
 };
 
 it('renders without crashing', () => {

--- a/src/lib/Components/TableBody/TableBody.tsx
+++ b/src/lib/Components/TableBody/TableBody.tsx
@@ -12,7 +12,7 @@ import { getExpandedGroups, getGroupedData } from '../../Utils/GroupUtils';
 import VirtualizedRows from '../VirtualizedRows/VirtualizedRows';
 
 export interface ITableBodyProps {
-  childAttributes?: ChildAttributes;
+  childAttributes: ChildAttributes;
   columns: Column[];
   data: any[];
   dataRow?: DataRowFunc;

--- a/src/lib/Components/VirtualizedRows/VirtualizedRows.test.tsx
+++ b/src/lib/Components/VirtualizedRows/VirtualizedRows.test.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { EditingMode } from '../../enums';
+import { ITableBodyProps } from '../TableBody/TableBody';
 import VirtualizedRows from './VirtualizedRows';
 
-const tableProps: any = {
+const tableProps: ITableBodyProps = {
+  childAttributes: {},
   columns: [
-    { key: 'column', name: 'Column 1' },
-    { key: 'column2', name: 'Column 2' },
+    { key: 'column', title: 'Column 1' },
+    { key: 'column2', title: 'Column 2' },
   ],
   data: [
     { column: 1, column2: 2, id: 1 },
     { column: 12, column2: 22, id: 2 },
   ],
+  dispatch: () => {},
+  editableCells: [],
+  editingMode: EditingMode.None,
+  groupColumnsCount: 0,
+  groupedColumns: [],
+  onOptionChange: () => {},
   rowKeyField: 'id',
+  selectedRows: [],
 };
 
 it('renders without crashing', () => {

--- a/src/lib/Models/AttributeTableData.ts
+++ b/src/lib/Models/AttributeTableData.ts
@@ -1,10 +1,10 @@
 import { HTMLAttributes } from 'react';
 
-import { ChildProps, DispatchFunc } from '../types';
+import { DispatchFunc } from '../types';
 
-export class AttributeTableData {
+export class AttributeTableData<T> {
   public baseFunc!: any;
   public childElementAttributes!: HTMLAttributes<HTMLElement>;
-  public childProps!: ChildProps;
   public dispatch!: DispatchFunc;
+  public childProps!: T;
 }

--- a/src/lib/Models/ChildAttributes.ts
+++ b/src/lib/Models/ChildAttributes.ts
@@ -1,5 +1,9 @@
+
+import { ITableAllProps } from '../';
+import { ICellContentProps } from '../Components/CellContent/CellContent';
 import { ChildAttributesItem } from '../types';
 
 export class ChildAttributes {
-  public cell?: ChildAttributesItem;
+  public cell?: ChildAttributesItem<ICellContentProps>;
+  public table?: ChildAttributesItem<ITableAllProps>;
 }

--- a/src/lib/Utils/FilterUtils.ts
+++ b/src/lib/Utils/FilterUtils.ts
@@ -6,8 +6,8 @@ import { FilterOperator } from '../Models/FilterOperator';
 import { getField } from './ColumnUtils';
 import { isEmpty } from './CommonUtils';
 
-export const getRowEditableCells = (rowKeyValue: any, editableCells?: Cell[]): Cell[] => {
-  return editableCells ? editableCells.filter((c) => c.rowKey === rowKeyValue) : [];
+export const getRowEditableCells = (rowKeyValue: any, editableCells: Cell[]): Cell[] => {
+  return editableCells.filter((c) => c.rowKey === rowKeyValue);
 };
 
 export const searchData = (columns: Column[], data: any[], searchText: string): any[] => {

--- a/src/lib/Utils/PropsUtils.test.ts
+++ b/src/lib/Utils/PropsUtils.test.ts
@@ -1,7 +1,8 @@
 import { HTMLAttributes } from 'react';
 
+import { ICellContentProps } from '../Components/CellContent/CellContent';
 import { EditingMode } from '../enums';
-import { ChildAttributesItem, ChildProps } from '../types';
+import { ChildAttributesItem } from '../types';
 import { mergeProps } from './PropsUtils';
 
 describe('PropsUtils', () => {
@@ -12,19 +13,21 @@ describe('PropsUtils', () => {
       onDoubleClick: () => {},
     };
 
-    const childProps: ChildProps = {
+    const dispatch = () => {};
+    const childProps: ICellContentProps = {
+      childAttributes: {},
       column: { key: 'column' },
-      dispatch: () => {},
+      dispatch,
       editingMode: EditingMode.Cell,
       field: 'column',
       rowData: { column: 1, column2: 2, id: 0 },
       rowKeyField: 'id',
     };
 
-    const childCustomAttributes: ChildAttributesItem = {
+    const childCustomAttributes: ChildAttributesItem<any> = {
       onClick: jest.fn(),
     };
-    const props = mergeProps(childElementAttributes, childProps, childCustomAttributes);
+    const props = mergeProps(childElementAttributes, childProps, childCustomAttributes, dispatch);
     const e: any = {name: 'eventName'};
     props.onClick!(e);
     expect(childCustomAttributes.onClick).toHaveBeenCalledTimes(1);

--- a/src/lib/Utils/PropsUtils.ts
+++ b/src/lib/Utils/PropsUtils.ts
@@ -1,13 +1,26 @@
 import { HTMLAttributes } from 'react';
 import { isFunction } from 'util';
 
-import { ChildAttributesItem, ChildProps } from '../types';
+import { ChildAttributesItem } from '../types';
+
+export const extendProps = (
+  childElementAttributes: HTMLAttributes<HTMLElement>,
+  childProps: any,
+  childCustomAttributes: ChildAttributesItem<any> | undefined,
+  dispatch: any): React.HTMLAttributes<HTMLElement> => {
+    let resultProps = childElementAttributes;
+    if (childCustomAttributes) {
+      resultProps = mergeProps(childElementAttributes, childProps, childCustomAttributes, dispatch);
+    }
+    return resultProps;
+};
 
 const emptyFunc = () => {};
 export const mergeProps = (
   childElementAttributes: HTMLAttributes<HTMLElement>,
-  childProps: ChildProps,
-  childCustomAttributes: ChildAttributesItem): React.HTMLAttributes<HTMLElement> => {
+  childProps: any,
+  childCustomAttributes: ChildAttributesItem<any>,
+  dispatch: any): React.HTMLAttributes<HTMLElement> => {
   const customPropsWithEvents: any = {};
   for (const prop in childCustomAttributes) {
     if (childCustomAttributes.hasOwnProperty(prop)) {
@@ -20,7 +33,7 @@ export const mergeProps = (
             baseFunc,
             childElementAttributes,
             childProps,
-            dispatch: childProps.dispatch,
+            dispatch,
           });
         };
       }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,4 +1,4 @@
-export * from './Models/AttributeTableData';
+
 export * from './Models/AttributeTableData';
 export * from './Models/Cell';
 export * from './Models/ChildAttributes';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,24 +1,22 @@
 import { PropsWithChildren } from 'react';
 
-import { ICellContentProps } from './Components/CellContent/CellContent';
 import { ICellEditorProps, IFilterRowEditorProps } from './Components/CellEditor/CellEditor';
 import { IDataRowProps } from './Components/DataRowContent/DataRowContent';
 import { IHeadCellProps } from './Components/HeadCell/HeadCell';
-import { Column } from './models';
-import { AttributeTableData } from './Models/AttributeTableData';
+import { ICellContentProps } from './interfaces';
+import { AttributeTableData, Column } from './models';
 
-type AddParameters<T> =
+type AddParameters<T, I> =
 T extends (e: infer E) => void ? (
-    (e: E, extendedEvent: AttributeTableData) => void
+    (e: E, extendedEvent: AttributeTableData<I>) => void
 ) : T;
-
-type WithExtraParameters<T> = {
-  [P in keyof T ] : AddParameters<T[P]>;
+type WithExtraParameters<T, I> = {
+  [P in keyof T ] : AddParameters<T[P], I>;
 };
 
-export type ChildProps = ICellContentProps;
 export type CellFunc = (props: CellFuncPropsWithChildren) => any;
 export type CellFuncPropsWithChildren = PropsWithChildren<ICellContentProps>;
+export type ChildAttributesItem<T> = WithExtraParameters<React.HTMLAttributes<HTMLElement>, T>;
 export type DataChangeFunc = (data: any[]) => void;
 export type DataRowFunc = (props: DataRowFuncPropsWithChildren) => any;
 export type DataRowFuncPropsWithChildren = PropsWithChildren<IDataRowProps>;
@@ -29,7 +27,6 @@ export type EventFunc = (type: string, data: any) => void;
 export type FilterRowFunc = (props: FilterRowFuncPropsWithChildren) => any;
 export type FilterRowFuncPropsWithChildren = PropsWithChildren<IFilterRowEditorProps>;
 export type FormatFunc = (value: any) => any;
-export type ChildAttributesItem = WithExtraParameters<React.HTMLAttributes<HTMLElement>>;
 export type HeaderCellFunc = (props: HeaderCellFuncPropsWithChildren) => any;
 export type HeaderCellFuncPropsWithChildren = PropsWithChildren<IHeadCellProps>;
 export type OptionChangeFunc = (value: any) => void;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,9 @@
 import { PropsWithChildren } from 'react';
 
+import { ICellContentProps } from './Components/CellContent/CellContent';
 import { ICellEditorProps, IFilterRowEditorProps } from './Components/CellEditor/CellEditor';
 import { IDataRowProps } from './Components/DataRowContent/DataRowContent';
 import { IHeadCellProps } from './Components/HeadCell/HeadCell';
-import { ICellContentProps } from './interfaces';
 import { AttributeTableData, Column } from './models';
 
 type AddParameters<T, I> =


### PR DESCRIPTION
example:
```
const childAttributes: ChildAttributes = {
  table: {
    onMouseEnter: (e, extendedEvent) => {
      const { dispatch } = extendedEvent;
      dispatch('MY_TABLE_onMouseEnter', { extendedEvent });
    },
    //....
  },
};

return <Table ... childAttributes={childAttributes}>
```

Demo: [Events](https://komarovalexander.github.io/ka-table/#/events)