### PR TITLE
Add kaPropsUtils.getData for obtaining ka-table visible data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "3.3.2",
+  "version": "3.4.1",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/public/static/icons/PagingDemo.svg
+++ b/public/static/icons/PagingDemo.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="path-1-inside-1" fill="white">
+<rect x="4" width="16" height="16" rx="1"/>
+</mask>
+<rect x="4" width="16" height="16" rx="1" stroke="#353C44" stroke-width="4" mask="url(#path-1-inside-1)"/>
+<mask id="path-2-inside-2" fill="white">
+<rect y="4" width="16" height="16" rx="1"/>
+</mask>
+<rect y="4" width="16" height="16" rx="1" fill="white" stroke="#353C44" stroke-width="4" mask="url(#path-2-inside-2)"/>
+</svg>

--- a/src/Demos/Demos.tsx
+++ b/src/Demos/Demos.tsx
@@ -21,6 +21,7 @@ import FilterRowCustomEditorDemo from './FilterRowCustomEditorDemo/FilterRowCust
 import FilterRowDemo from './FilterRowDemo/FilterRowDemo';
 import { initializeGA, trackEvent } from './ga';
 import { withTracker } from './GAWrapper';
+import GetDataByPropsDemo from './GetDataByPropsDemo/GetDataByPropsDemo';
 import GroupingCustomCellDemo from './GroupingCustomCellDemo/GroupingCustomCellDemo';
 import GroupingCustomRowDemo from './GroupingCustomRowDemo/GroupingCustomRowDemo';
 import GroupingDemo from './GroupingDemo/GroupingDemo';
@@ -57,6 +58,7 @@ const demos: Demo[] = [
   new Demo(FilterExtendedDemo, '/filter-extended', 'Filter Extended', 'FilterExtendedDemo', 'https://stackblitz.com/edit/table-filter-extended-js', 'https://stackblitz.com/edit/table-filter-extended-ts'),
   new Demo(FilterRowDemo, '/filter-row', 'Filter Row', 'FilterRowDemo', 'https://stackblitz.com/edit/table-filter-row-js', 'https://stackblitz.com/edit/table-filter-row-ts'),
   new Demo(FilterRowCustomEditorDemo, '/filter-row-custom-editor', 'Filter Row - Custom Editor', 'FilterRowCustomEditorDemo', 'https://stackblitz.com/edit/table-filter-row-custom-editor-js', 'https://stackblitz.com/edit/table-filter-row-custom-editor-ts'),
+  new Demo(GetDataByPropsDemo, '/get-data-by-props', 'Get Data By Props', 'ObtainTableDataDemo', 'https://stackblitz.com/edit/table-get-data-by-props-js', 'https://stackblitz.com/edit/table-get-data-by-props-ts'),
   new Demo(GroupingDemo, '/grouping', 'Grouping', 'GroupingDemo', 'https://stackblitz.com/edit/table-grouping-js', 'https://stackblitz.com/edit/table-grouping-ts', true),
   new Demo(GroupingCustomCellDemo, '/grouping-custom-cell', 'Grouping Custom Cell', 'GroupingCustomCellDemo', 'https://stackblitz.com/edit/table-grouping-custom-cell-js', 'https://stackblitz.com/edit/table-grouping-custom-cell-ts', true),
   new Demo(GroupingCustomRowDemo, '/grouping-custom-row', 'Grouping Custom Row', 'GroupingCustomRowDemo', 'https://stackblitz.com/edit/table-grouping-custom-row-js', 'https://stackblitz.com/edit/table-grouping-custom-row-ts', true),

--- a/src/Demos/Demos.tsx
+++ b/src/Demos/Demos.tsx
@@ -58,7 +58,7 @@ const demos: Demo[] = [
   new Demo(FilterExtendedDemo, '/filter-extended', 'Filter Extended', 'FilterExtendedDemo', 'https://stackblitz.com/edit/table-filter-extended-js', 'https://stackblitz.com/edit/table-filter-extended-ts'),
   new Demo(FilterRowDemo, '/filter-row', 'Filter Row', 'FilterRowDemo', 'https://stackblitz.com/edit/table-filter-row-js', 'https://stackblitz.com/edit/table-filter-row-ts'),
   new Demo(FilterRowCustomEditorDemo, '/filter-row-custom-editor', 'Filter Row - Custom Editor', 'FilterRowCustomEditorDemo', 'https://stackblitz.com/edit/table-filter-row-custom-editor-js', 'https://stackblitz.com/edit/table-filter-row-custom-editor-ts'),
-  new Demo(GetDataByPropsDemo, '/get-data-by-props', 'Get Data By Props', 'ObtainTableDataDemo', 'https://stackblitz.com/edit/table-get-data-by-props-js', 'https://stackblitz.com/edit/table-get-data-by-props-ts'),
+  new Demo(GetDataByPropsDemo, '/get-data-by-props', 'Get Data By Props', 'GetDataByPropsDemo', 'https://stackblitz.com/edit/table-get-data-by-props-js', 'https://stackblitz.com/edit/table-get-data-by-props-ts'),
   new Demo(GroupingDemo, '/grouping', 'Grouping', 'GroupingDemo', 'https://stackblitz.com/edit/table-grouping-js', 'https://stackblitz.com/edit/table-grouping-ts', true),
   new Demo(GroupingCustomCellDemo, '/grouping-custom-cell', 'Grouping Custom Cell', 'GroupingCustomCellDemo', 'https://stackblitz.com/edit/table-grouping-custom-cell-js', 'https://stackblitz.com/edit/table-grouping-custom-cell-ts', true),
   new Demo(GroupingCustomRowDemo, '/grouping-custom-row', 'Grouping Custom Row', 'GroupingCustomRowDemo', 'https://stackblitz.com/edit/table-grouping-custom-row-js', 'https://stackblitz.com/edit/table-grouping-custom-row-ts', true),

--- a/src/Demos/GetDataByPropsDemo/GetDataByPropsDemo.scss
+++ b/src/Demos/GetDataByPropsDemo/GetDataByPropsDemo.scss
@@ -1,0 +1,7 @@
+.obtain-table-data-demo{
+  .table-data {
+    background-color: white;
+    padding: 1px 20px;
+    margin-top: 20px;
+  }
+}

--- a/src/Demos/GetDataByPropsDemo/GetDataByPropsDemo.test.tsx
+++ b/src/Demos/GetDataByPropsDemo/GetDataByPropsDemo.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import GetDataByPropsDemo from './GetDataByPropsDemo';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<GetDataByPropsDemo />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/src/Demos/GetDataByPropsDemo/GetDataByPropsDemo.tsx
+++ b/src/Demos/GetDataByPropsDemo/GetDataByPropsDemo.tsx
@@ -1,0 +1,68 @@
+import './GetDataByPropsDemo.scss';
+
+import React, { useState } from 'react';
+
+import { ITableProps, kaReducer, Table } from '../../lib';
+import { search } from '../../lib/actionCreators';
+import { DataType, EditingMode, FilteringMode, SortDirection, SortingMode } from '../../lib/enums';
+import { DispatchFunc } from '../../lib/types';
+import { kaPropsUtils } from '../../lib/utils';
+
+const dataArray: any[] = [
+  { id: 1, name: 'Mike Wazowski', score: 80, passed: true },
+  { id: 2, name: 'Billi Bob', score: 55, passed: false, nextTry: new Date(2019, 10, 8, 10) },
+  { id: 3, name: 'Tom Williams', score: 45, passed: false, nextTry: new Date(2019, 11, 8, 10) },
+  { id: 4, name: 'Kurt Cobain', score: 75, passed: true },
+  { id: 5, name: 'Marshall Bruce', score: 77, passed: true },
+  { id: 6, name: 'Sunny Fox', score: 33, passed: false, nextTry: new Date(2019, 10, 9, 10) },
+];
+
+const tablePropsInit: ITableProps = {
+  columns: [
+    { dataType: DataType.String, key: 'name', title: 'Name', sortDirection: SortDirection.Ascend },
+    { key: 'score', title: 'Score', dataType: DataType.Number },
+    {
+      dataType: DataType.Boolean,
+      key: 'passed',
+      title: 'Passed',
+    },
+    {
+      dataType: DataType.Date,
+      format: (value: Date) => value && value.toLocaleDateString('en', { month: '2-digit', day: '2-digit', year: 'numeric' }),
+      key: 'nextTry',
+      title: 'Next Try',
+    },
+  ],
+  data: dataArray,
+  editingMode: EditingMode.Cell,
+  rowKeyField: 'id',
+  filteringMode: FilteringMode.FilterRow,
+  sortingMode: SortingMode.Single,
+};
+
+const GetDataByPropsDemo: React.FC = () => {
+  const [tableProps, changeTableProps] = useState(tablePropsInit);
+  const dispatch: DispatchFunc = (action) => {
+    changeTableProps((prevState: ITableProps) => kaReducer(prevState, action));
+  };
+
+  const data = kaPropsUtils.getData(tableProps);
+
+  return (
+    <div className='obtain-table-data-demo'>
+      <input type='search' defaultValue={tableProps.search} onChange={(event) => {
+        dispatch(search(event.currentTarget.value));
+      }} className='top-element'/>
+      <Table
+        {...tableProps}
+        dispatch={dispatch}
+      />
+      <div className='table-data'>
+        <h4>Table Data:</h4>
+        <pre className='data'>{JSON.stringify(data, null, 2)}</pre>
+      </div>
+    </div>
+  );
+};
+
+export default GetDataByPropsDemo;

--- a/src/lib/Utils/PropsUtils.test.ts
+++ b/src/lib/Utils/PropsUtils.test.ts
@@ -1,9 +1,10 @@
 import { HTMLAttributes } from 'react';
 
+import { ITableProps } from '../';
 import { ICellContentProps } from '../Components/CellContent/CellContent';
-import { EditingMode } from '../enums';
+import { DataType, EditingMode, SortDirection } from '../enums';
 import { ChildAttributesItem } from '../types';
-import { mergeProps } from './PropsUtils';
+import { getData, mergeProps } from './PropsUtils';
 
 describe('PropsUtils', () => {
   it('mergeProps', () => {
@@ -39,3 +40,66 @@ describe('PropsUtils', () => {
     });
   });
 });
+
+describe('getData', () => {
+  const dataArray = Array(5).fill(undefined).map(
+    (_, index) => ({
+      column1: `column:1 row:${index}`,
+      column2: `column:2 row:${index}`,
+      column3: `column:3 row:${index}`,
+      column4: `column:4 row:${index}`,
+      id: index,
+    }),
+  );
+  const props: ITableProps = {
+    data: dataArray,
+    columns: [
+      { key: 'column1', title: 'Column 1', dataType: DataType.String },
+      { key: 'column2', title: 'Column 2', dataType: DataType.String },
+      { key: 'column3', title: 'Column 3', dataType: DataType.String },
+      { key: 'column4', title: 'Column 4', dataType: DataType.String },
+    ],
+    rowKeyField: 'id'
+  }
+  it('get data by search', () => {
+    const result = getData({ ...props , search: 'row:3' });
+    expect(result).toMatchSnapshot();
+  });
+  it('get data by filter', () => {
+    const result = getData({ ...props , columns: [
+      {
+        key: 'column1',
+        title: 'Column 1',
+        dataType: DataType.String,
+        filterRowValue: 'column:1 row:2'
+      }
+    ] });
+    expect(result).toMatchSnapshot();
+  });
+
+  it('get data by extendedFilter', () => {
+    const result = getData({ ...props , extendedFilter: (data) => data.filter(i => i.id === 1) });
+    expect(result).toMatchSnapshot();
+  });
+
+  it('get sorted data', () => {
+    const result = getData({ ...props , columns: [{
+      key: 'column1',
+      title: 'Column 1',
+      dataType: DataType.String,
+      sortDirection: SortDirection.Descend
+    }]});
+    expect(result).toMatchSnapshot();
+  });
+
+  it('get paged data', () => {
+    const result = getData({ ...props , paging: { enabled: true, pageIndex: 1, pageSize: 2 }});
+    expect(result).toMatchSnapshot();
+  });
+
+  it('get grouped data', () => {
+    const result = getData({ ...props , groups: [{ columnKey: 'column1' }] });
+    expect(result).toMatchSnapshot();
+  });
+});
+

--- a/src/lib/Utils/PropsUtils.ts
+++ b/src/lib/Utils/PropsUtils.ts
@@ -57,25 +57,43 @@ export const mergeProps = (
   return mergedResult;
 };
 
-export const prepareTableOptions = (props: ITableProps) => {
+export const getData = (props: ITableProps) => {
   const {
     extendedFilter,
+    columns,
     groups,
     groupsExpanded,
     paging,
     search,
   } = props;
   let {
-    columns,
     data = [],
   } = props;
+  data = [...data];
   data = extendedFilter ? extendedFilter(data) : data;
   data = search ? searchData(columns, data, search) : data;
-
   data = convertToColumnTypes(data, columns);
-
   data = filterData(data, columns);
   data = sortData(columns, data);
+
+  const groupedColumns: Column[] = groups ? columns.filter((c) => groups.some((g) => g.columnKey === c.key)) : [];
+  const groupedData = groups ? getGroupedData(data, groups, groupedColumns, groupsExpanded) : data;
+  data = getPageData(groupedData, paging);
+
+  return data;
+};
+
+export const prepareTableOptions = (props: ITableProps) => {
+  const {
+    data = [],
+    groups,
+    paging,
+  } = props;
+  let {
+    columns,
+  } = props;
+
+  const groupedData = getData(props);
 
   let groupColumnsCount = 0;
   let groupedColumns: Column[] = [];
@@ -84,14 +102,10 @@ export const prepareTableOptions = (props: ITableProps) => {
     groupedColumns = columns.filter((c) => groups.some((g) => g.columnKey === c.key));
     columns = columns.filter((c) => !groups.some((g) => g.columnKey === c.key));
   }
-
-  const groupedAllData = groups ? getGroupedData(data, groups, groupedColumns, groupsExpanded) : data;
-  const pagesCount = getPagesCount(groupedAllData, paging);
-  const groupedData = getPageData(groupedAllData, paging);
-
+  const pagesCount = getPagesCount(data, paging);
   return {
     columns,
-    data,
+    data: groupedData, // TODO: deprecate it in 4.0.0
     groupColumnsCount,
     groupedColumns,
     groupedData,

--- a/src/lib/Utils/__snapshots__/PropsUtils.test.ts.snap
+++ b/src/lib/Utils/__snapshots__/PropsUtils.test.ts.snap
@@ -1,0 +1,171 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getData get data by extendedFilter 1`] = `
+Array [
+  Object {
+    "column1": "column:1 row:1",
+    "column2": "column:2 row:1",
+    "column3": "column:3 row:1",
+    "column4": "column:4 row:1",
+    "id": 1,
+  },
+]
+`;
+
+exports[`getData get data by filter 1`] = `
+Array [
+  Object {
+    "column1": "column:1 row:2",
+    "column2": "column:2 row:2",
+    "column3": "column:3 row:2",
+    "column4": "column:4 row:2",
+    "id": 2,
+  },
+]
+`;
+
+exports[`getData get data by search 1`] = `
+Array [
+  Object {
+    "column1": "column:1 row:3",
+    "column2": "column:2 row:3",
+    "column3": "column:3 row:3",
+    "column4": "column:4 row:3",
+    "id": 3,
+  },
+]
+`;
+
+exports[`getData get grouped data 1`] = `
+Array [
+  Object {
+    "groupMark": Object {},
+    "key": Array [
+      "column:1 row:0",
+    ],
+    "value": "column:1 row:0",
+  },
+  Object {
+    "column1": "column:1 row:0",
+    "column2": "column:2 row:0",
+    "column3": "column:3 row:0",
+    "column4": "column:4 row:0",
+    "id": 0,
+  },
+  Object {
+    "groupMark": Object {},
+    "key": Array [
+      "column:1 row:1",
+    ],
+    "value": "column:1 row:1",
+  },
+  Object {
+    "column1": "column:1 row:1",
+    "column2": "column:2 row:1",
+    "column3": "column:3 row:1",
+    "column4": "column:4 row:1",
+    "id": 1,
+  },
+  Object {
+    "groupMark": Object {},
+    "key": Array [
+      "column:1 row:2",
+    ],
+    "value": "column:1 row:2",
+  },
+  Object {
+    "column1": "column:1 row:2",
+    "column2": "column:2 row:2",
+    "column3": "column:3 row:2",
+    "column4": "column:4 row:2",
+    "id": 2,
+  },
+  Object {
+    "groupMark": Object {},
+    "key": Array [
+      "column:1 row:3",
+    ],
+    "value": "column:1 row:3",
+  },
+  Object {
+    "column1": "column:1 row:3",
+    "column2": "column:2 row:3",
+    "column3": "column:3 row:3",
+    "column4": "column:4 row:3",
+    "id": 3,
+  },
+  Object {
+    "groupMark": Object {},
+    "key": Array [
+      "column:1 row:4",
+    ],
+    "value": "column:1 row:4",
+  },
+  Object {
+    "column1": "column:1 row:4",
+    "column2": "column:2 row:4",
+    "column3": "column:3 row:4",
+    "column4": "column:4 row:4",
+    "id": 4,
+  },
+]
+`;
+
+exports[`getData get paged data 1`] = `
+Array [
+  Object {
+    "column1": "column:1 row:2",
+    "column2": "column:2 row:2",
+    "column3": "column:3 row:2",
+    "column4": "column:4 row:2",
+    "id": 2,
+  },
+  Object {
+    "column1": "column:1 row:3",
+    "column2": "column:2 row:3",
+    "column3": "column:3 row:3",
+    "column4": "column:4 row:3",
+    "id": 3,
+  },
+]
+`;
+
+exports[`getData get sorted data 1`] = `
+Array [
+  Object {
+    "column1": "column:1 row:4",
+    "column2": "column:2 row:4",
+    "column3": "column:3 row:4",
+    "column4": "column:4 row:4",
+    "id": 4,
+  },
+  Object {
+    "column1": "column:1 row:3",
+    "column2": "column:2 row:3",
+    "column3": "column:3 row:3",
+    "column4": "column:4 row:3",
+    "id": 3,
+  },
+  Object {
+    "column1": "column:1 row:2",
+    "column2": "column:2 row:2",
+    "column3": "column:3 row:2",
+    "column4": "column:4 row:2",
+    "id": 2,
+  },
+  Object {
+    "column1": "column:1 row:1",
+    "column2": "column:2 row:1",
+    "column3": "column:3 row:1",
+    "column4": "column:4 row:1",
+    "id": 1,
+  },
+  Object {
+    "column1": "column:1 row:0",
+    "column2": "column:2 row:0",
+    "column3": "column:3 row:0",
+    "column4": "column:4 row:0",
+    "id": 0,
+  },
+]
+`;

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -24,12 +24,12 @@ export enum ActionType {
   SelectRow = 'SelectRow',
   SelectSingleRow = 'SelectSingleRow',
   ShowLoading = 'ShowLoading',
-  UpdatePageIndex = 'UpdatePageIndex',
   UpdateCellValue = 'UpdateCellValue',
   UpdateData = 'UpdateData',
   UpdateFilterRowOperator = 'UpdateFilterRowOperator',
   UpdateFilterRowValue = 'UpdateFilterRowValue',
   UpdateGroupsExpanded = 'UpdateGroupsExpanded',
+  UpdatePageIndex = 'UpdatePageIndex',
   UpdateSortDirection = 'UpdateSortDirection',
   UpdateVirtualScrolling = 'UpdateVirtualScrolling',
 }

--- a/src/lib/style.scss
+++ b/src/lib/style.scss
@@ -177,4 +177,5 @@
 .ka-paging-page-index-active{
   background-color: #F1F5F7;
   font-weight: bold;
+  color: #747D86;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,13 @@
 
 import * as columnUtils from './Utils/ColumnUtils';
 import * as dateUtils from './Utils/DateUtils';
+import * as kaPropsUtils from './Utils/PropsUtils';
 import * as typeUtils from './Utils/TypeUtils';
 
+// TODO: add ka prefix in 4.0.0
 export {
   columnUtils,
-  typeUtils,
   dateUtils,
+  kaPropsUtils,
+  typeUtils,
 };


### PR DESCRIPTION
#54 
Obtains sorted, filtered, grouped, paged data for table according to TableProps

Docs: [kaPropsUtils.getData](http://ka-table.com/docs_props.html#kapropsutilsgetdata)
Demo:  [Get Data By Props](https://komarovalexander.github.io/ka-table/#/get-data-by-props)