### PR TITLE
Resizing improvements: Add columnResizing to ITableProps & headCellResize to childComponents 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "6.4.3",
+  "version": "6.5.0",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/src/Demos/ColumnResizingDemo/ColumnResizingDemo.tsx
+++ b/src/Demos/ColumnResizingDemo/ColumnResizingDemo.tsx
@@ -13,7 +13,6 @@ const columns: Column[] = Array(15).fill(undefined).map(
     style: { width: 150 },
     title: 'Column ' + index,
     type: DataType.String,
-    isResizable: true,
   }),
 );
 
@@ -25,11 +24,12 @@ const dataArray = Array(30).fill(undefined).map(
 );
 
 const tablePropsInit: ITableProps = {
-  columns,
-  data: dataArray,
-  editingMode: EditingMode.Cell,
-  rowKeyField: 'id',
   sortingMode: SortingMode.Single,
+  rowKeyField: 'id',
+  editingMode: EditingMode.Cell,
+  data: dataArray,
+  columns,
+  columnResizing: true,
 };
 
 const ColumnResizingDemo: React.FC = () => {

--- a/src/Demos/DemoText.tsx
+++ b/src/Demos/DemoText.tsx
@@ -10,7 +10,7 @@ interface IDemoTextProps {
 const DemoText: React.FunctionComponent<IDemoTextProps> = ({ demoFileName }) => {
   const [text, changeText]: [string, any] = useState('');
   useEffect(() => {
-    fetch(`demos/${demoFileName}/${demoFileName}.tsx?c=6`)
+    fetch(`demos/${demoFileName}/${demoFileName}.tsx?c=7`)
       .then((res) => res.text())
       .then((fileText) => changeText(fileText));
   }, [demoFileName]);

--- a/src/lib/Components/HeadCell/HeadCell.tsx
+++ b/src/lib/Components/HeadCell/HeadCell.tsx
@@ -4,7 +4,7 @@ import { reorderColumns } from '../../actionCreators';
 import defaultOptions from '../../defaultOptions';
 import { IHeadCellProps } from '../../props';
 import { ChildAttributesItem } from '../../types';
-import { headCellDispatchWrapper } from '../../Utils/CellResizeUtils';
+import { headCellDispatchWrapper, isCellResizeShown } from '../../Utils/CellResizeUtils';
 import { addElementAttributes, getElementCustomization } from '../../Utils/ComponentUtils';
 import { getDraggableProps } from '../../Utils/PropsUtils';
 import { isSortingEnabled } from '../../Utils/SortUtils';
@@ -14,6 +14,7 @@ import HeadCellResize from '../HeadCellResize/HeadCellResize';
 const HeadCell: React.FunctionComponent<IHeadCellProps> = (props) => {
   const {
     columnReordering,
+    columnResizing,
     column: { style, isResizable, key },
     dispatch,
     sortingMode
@@ -42,7 +43,7 @@ const HeadCell: React.FunctionComponent<IHeadCellProps> = (props) => {
         <div className={defaultOptions.css.theadCellContentWrapper}>
          {content || <HeadCellContent {...props}/>}
         </div>
-        {isResizable && (
+        {isCellResizeShown(isResizable, columnResizing) && (
           <HeadCellResize {...props}
             currentWidth={width}
             dispatch={headCellDispatch}/>

--- a/src/lib/Components/HeadCellResize/HeadCellResize.test.tsx
+++ b/src/lib/Components/HeadCellResize/HeadCellResize.test.tsx
@@ -13,6 +13,7 @@ const props = {
   column: new Column(),
   dispatch: jest.fn(),
   currentWidth: 100,
+  childComponents: {}
 };
 
 it('renders without crashing', () => {

--- a/src/lib/Components/HeadCellResize/HeadCellResize.tsx
+++ b/src/lib/Components/HeadCellResize/HeadCellResize.tsx
@@ -2,39 +2,41 @@ import * as React from 'react';
 
 import { resizeColumn } from '../../actionCreators';
 import defaultOptions from '../../defaultOptions';
-import { Column } from '../../Models/Column';
-import { DispatchFunc } from '../../types';
+import { IHeadCellResizeProps } from '../../props';
 import {
   getMinWidth, getMouseMove, getValidatedWidth, HeadCellResizeStateAction,
 } from '../../Utils/CellResizeUtils';
+import { getElementCustomization } from '../../Utils/ComponentUtils';
 import { getEventListenerEffect } from '../../Utils/EffectUtils';
 
-const HeadCellResize: React.FunctionComponent<{
-  dispatch: DispatchFunc,
-  column: Column,
-  currentWidth: any,
-}> = (props) => {
+const HeadCellResize: React.FunctionComponent<IHeadCellResizeProps> = (props) => {
   const {
     column: { key, style },
     dispatch,
     currentWidth,
+    childComponents
   } = props;
   const minWidth = getMinWidth(style);
+
+  const { elementAttributes, content } = getElementCustomization({
+    className: defaultOptions.css.theadCellResize,
+    draggable: false,
+    onMouseDown: (mouseDownEvent: any) => {
+      mouseDownEvent.preventDefault();
+      const startX = mouseDownEvent.screenX - mouseDownEvent.currentTarget.parentElement.offsetWidth;
+      const mouseMoveStop = getEventListenerEffect('mousemove', getMouseMove(currentWidth, minWidth, startX, dispatch));
+      const mouseUpStop = getEventListenerEffect('mouseup', (event: MouseEvent) => {
+        const newWidth = getValidatedWidth(event.screenX - startX, minWidth);
+        dispatch(resizeColumn(key, newWidth));
+        dispatch({ type: HeadCellResizeStateAction, width: newWidth });
+        mouseUpStop();
+        mouseMoveStop();
+      });
+    }
+  }, props, childComponents.headCellResize);
+
   return (
-    <div className={defaultOptions.css.theadCellResize}
-      draggable='false'
-      onMouseDown={(mouseDownEvent: any) => {
-        mouseDownEvent.preventDefault();
-        const startX = mouseDownEvent.screenX - mouseDownEvent.currentTarget.parentElement.offsetWidth;
-        const mouseMoveStop = getEventListenerEffect('mousemove', getMouseMove(currentWidth, minWidth, startX, dispatch));
-        const mouseUpStop = getEventListenerEffect('mouseup', (event: MouseEvent) => {
-          const newWidth = getValidatedWidth(event.screenX - startX, minWidth);
-          dispatch(resizeColumn(key, newWidth));
-          dispatch({ type: HeadCellResizeStateAction, width: newWidth });
-          mouseUpStop();
-          mouseMoveStop();
-        });
-      }}>&nbsp;</div>
+    <div {...elementAttributes}>{content || <>&nbsp;</>}</div>
   );
 };
 

--- a/src/lib/Components/HeadRow/HeadRow.tsx
+++ b/src/lib/Components/HeadRow/HeadRow.tsx
@@ -5,30 +5,20 @@ import { IHeadRowProps } from '../../props';
 import EmptyCells from '../EmptyCells/EmptyCells';
 import HeadCell from '../HeadCell/HeadCell';
 
-const HeadRow: React.FunctionComponent<IHeadRowProps> = ({
-  areAllRowsSelected,
-  childComponents,
-  columnReordering,
-  columnResizing,
-  columns,
-  dispatch,
-  groupColumnsCount,
-  sortingMode,
-}) => {
+const HeadRow: React.FunctionComponent<IHeadRowProps> = (props) => {
+  const {
+    columns,
+    groupColumnsCount,
+  } = props;
   return (
     <tr className={defaultOptions.css.theadRow}>
       <EmptyCells count={groupColumnsCount} isTh={true}/>
       {columns.map((column) => {
         return (
           <HeadCell
-            areAllRowsSelected={areAllRowsSelected}
-            childComponents={childComponents}
-            columnReordering={columnReordering}
-            columnResizing={columnResizing}
+            {...props}
             column={column}
-            dispatch={dispatch}
             key={column.key}
-            sortingMode={sortingMode}
           />
         );
       })}

--- a/src/lib/Components/HeadRow/HeadRow.tsx
+++ b/src/lib/Components/HeadRow/HeadRow.tsx
@@ -9,6 +9,7 @@ const HeadRow: React.FunctionComponent<IHeadRowProps> = ({
   areAllRowsSelected,
   childComponents,
   columnReordering,
+  columnResizing,
   columns,
   dispatch,
   groupColumnsCount,
@@ -23,6 +24,7 @@ const HeadRow: React.FunctionComponent<IHeadRowProps> = ({
             areAllRowsSelected={areAllRowsSelected}
             childComponents={childComponents}
             columnReordering={columnReordering}
+            columnResizing={columnResizing}
             column={column}
             dispatch={dispatch}
             key={column.key}

--- a/src/lib/Components/Table/Table.tsx
+++ b/src/lib/Components/Table/Table.tsx
@@ -68,7 +68,7 @@ export const Table: React.FunctionComponent<ITableAllProps> = (props) => {
 
   const { elementAttributes, content: rootDivContent } = getElementCustomization({
     className:  kaCss
-  }, { ...props, dispatch }, childComponents.rootDiv);
+  }, props, childComponents.rootDiv);
   elementAttributes.style = {width, height, ...elementAttributes.style}
 
   React.useEffect(() => {

--- a/src/lib/Components/Table/Table.tsx
+++ b/src/lib/Components/Table/Table.tsx
@@ -18,6 +18,7 @@ import { TableWrapper } from '../TableWrapper/TableWrapper';
 
 export interface ITableProps {
   columnReordering?: boolean;
+  columnResizing?: boolean;
   columns: Column[];
   data?: any[];
   detailsRows?: any[];

--- a/src/lib/Components/TableBody/TableBody.tsx
+++ b/src/lib/Components/TableBody/TableBody.tsx
@@ -8,12 +8,11 @@ import TableBodyContent from '../TableBodyContent/TableBodyContent';
 const TableBody: React.FunctionComponent<ITableBodyProps> = (props) => {
   const {
     childComponents,
-    dispatch,
   } = props;
 
   const { elementAttributes, content } = getElementCustomization({
     className: defaultOptions.css.tbody,
-  }, { ...props, dispatch }, childComponents.tableBody);
+  }, props, childComponents.tableBody);
   return (
     <tbody {...elementAttributes} className={defaultOptions.css.tbody}>
       {content || <TableBodyContent {...props} />}

--- a/src/lib/Components/TableHead/TableHead.tsx
+++ b/src/lib/Components/TableHead/TableHead.tsx
@@ -9,42 +9,20 @@ import HeadRow from '../HeadRow/HeadRow';
 
 export const TableHead: React.FunctionComponent<ITableHeadProps> = (props) => {
   const {
-    areAllRowsSelected,
     childComponents,
-    columnReordering,
-    columnResizing,
-    columns,
-    dispatch,
     filteringMode,
-    groupColumnsCount,
-    sortingMode,
   } = props;
-
   const { elementAttributes, content } = getElementCustomization({
     className: defaultOptions.css.thead,
-  }, { ...props, dispatch }, childComponents.tableHead);
+  }, props, childComponents.tableHead);
   return (
     <thead {...elementAttributes}>
       {content || (
         <>
-          <HeadRow
-            areAllRowsSelected={areAllRowsSelected}
-            childComponents={childComponents}
-            columnReordering={columnReordering}
-            columnResizing={columnResizing}
-            columns={columns}
-            dispatch={dispatch}
-            groupColumnsCount={groupColumnsCount}
-            sortingMode={sortingMode}
-          />
+          <HeadRow {...props} />
           {filteringMode === FilteringMode.FilterRow &&
             (
-              <FilterRow
-                childComponents={childComponents}
-                columns={columns}
-                dispatch={dispatch}
-                groupColumnsCount={groupColumnsCount}
-              />
+              <FilterRow {...props} />
             )}
         </>
       )}

--- a/src/lib/Components/TableHead/TableHead.tsx
+++ b/src/lib/Components/TableHead/TableHead.tsx
@@ -12,6 +12,7 @@ export const TableHead: React.FunctionComponent<ITableHeadProps> = (props) => {
     areAllRowsSelected,
     childComponents,
     columnReordering,
+    columnResizing,
     columns,
     dispatch,
     filteringMode,
@@ -30,6 +31,7 @@ export const TableHead: React.FunctionComponent<ITableHeadProps> = (props) => {
             areAllRowsSelected={areAllRowsSelected}
             childComponents={childComponents}
             columnReordering={columnReordering}
+            columnResizing={columnResizing}
             columns={columns}
             dispatch={dispatch}
             groupColumnsCount={groupColumnsCount}

--- a/src/lib/Components/TableWrapper/TableWrapper.tsx
+++ b/src/lib/Components/TableWrapper/TableWrapper.tsx
@@ -44,11 +44,11 @@ export const TableWrapper: React.FunctionComponent<ITableAllProps> = (props) => 
         type: ActionType.ScrollTable,
       });
     } : undefined,
-  }, { ...props, dispatch }, childComponents.tableWrapper);
+  }, props, childComponents.tableWrapper);
 
   const { elementAttributes, content } = getElementCustomization({
     className: defaultOptions.css.table,
-  }, { ...props, dispatch }, childComponents.table);
+  }, props, childComponents.table);
   return (
     <div {...tableWrapper.elementAttributes}>
       {content || tableWrapper.content || (

--- a/src/lib/Components/TableWrapper/TableWrapper.tsx
+++ b/src/lib/Components/TableWrapper/TableWrapper.tsx
@@ -13,6 +13,7 @@ export const TableWrapper: React.FunctionComponent<ITableAllProps> = (props) => 
   const {
     childComponents = {},
     columnReordering,
+    columnResizing,
     data = [],
     dispatch,
     editableCells = [],
@@ -56,6 +57,7 @@ export const TableWrapper: React.FunctionComponent<ITableAllProps> = (props) => 
             areAllRowsSelected={areAllRowsSelected}
             childComponents={childComponents}
             columnReordering={columnReordering}
+            columnResizing={columnResizing}
             columns={preparedOptions.columns}
             dispatch={dispatch}
             filteringMode={filteringMode}

--- a/src/lib/Models/ChildComponents.ts
+++ b/src/lib/Models/ChildComponents.ts
@@ -1,8 +1,8 @@
 import { ITableProps } from '../';
 import {
   ICellEditorProps, ICellProps, ICellTextProps, IDataRowProps, IFilterRowEditorProps,
-  IGroupRowProps, IHeadCellProps, INoDataRowProps, IPagingIndexProps, IPagingPagesProps,
-  ITableBodyProps, ITableHeadProps,
+  IGroupRowProps, IHeadCellProps, IHeadCellResizeProps, INoDataRowProps, IPagingIndexProps,
+  IPagingPagesProps, ITableBodyProps, ITableHeadProps,
 } from '../props';
 import { ChildComponent } from './ChildComponent';
 
@@ -26,4 +26,5 @@ export class ChildComponents {
   public tableBody?: ChildComponent<ITableBodyProps>;
   public tableHead?: ChildComponent<ITableHeadProps>;
   public tableWrapper?: ChildComponent<ITableProps>;
+  public headCellResize?: ChildComponent<IHeadCellResizeProps>;
 }

--- a/src/lib/Utils/CellResizeUtils.test.ts
+++ b/src/lib/Utils/CellResizeUtils.test.ts
@@ -1,6 +1,7 @@
 
 import {
   getMinWidth, getMouseMove, getValidatedWidth, headCellDispatchWrapper, HeadCellResizeStateAction,
+  isCellResizeShown,
 } from './CellResizeUtils';
 
 describe('CellUtils', () => {
@@ -54,5 +55,17 @@ describe('CellUtils', () => {
       mouseMoveEvent({ screenX: 40 } as any);
       expect(dispatch).toHaveBeenCalledTimes(0);
     });
+  });
+
+  it('isCellResizeShown', () => {
+    expect(isCellResizeShown(false, false)).toBeFalsy();
+    expect(isCellResizeShown(false, true)).toBeFalsy();
+    expect(isCellResizeShown(false, undefined)).toBeFalsy();
+    expect(isCellResizeShown(true, false)).toBeTruthy();
+    expect(isCellResizeShown(true, false)).toBeTruthy();
+    expect(isCellResizeShown(true, undefined)).toBeTruthy();
+    expect(isCellResizeShown(undefined, true)).toBeTruthy();
+    expect(isCellResizeShown(undefined, false)).toBeFalsy();
+    expect(isCellResizeShown(undefined, undefined)).toBeFalsy();
   });
 });

--- a/src/lib/Utils/CellResizeUtils.ts
+++ b/src/lib/Utils/CellResizeUtils.ts
@@ -2,6 +2,8 @@ import { DispatchFunc } from '../types';
 
 export const HeadCellResizeStateAction = 'HeadCellResizeStateAction';
 
+export const isCellResizeShown = (isResizable?: boolean, columnResizing?: boolean): boolean => !!((isResizable !== false) && (columnResizing || isResizable));
+
 export const getMouseMove = (
   currentWidth: any,
   minWidth: number,

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -93,6 +93,12 @@ export interface IGroupRowProps {
   text: string;
 }
 
+export interface IHeadCellResizeProps {
+  dispatch: DispatchFunc;
+  column: Column;
+  currentWidth: any;
+  childComponents: ChildComponents;
+}
 export interface IHeadCellProps {
   areAllRowsSelected: boolean;
   childComponents: ChildComponents;

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -97,6 +97,7 @@ export interface IHeadCellProps {
   areAllRowsSelected: boolean;
   childComponents: ChildComponents;
   columnReordering?: boolean;
+  columnResizing?: boolean;
   column: Column;
   dispatch: DispatchFunc;
   sortingMode: SortingMode;
@@ -110,6 +111,7 @@ export interface INoDataRowProps {
 
 export interface ITableHeadProps {
   columnReordering?: boolean;
+  columnResizing?: boolean;
   areAllRowsSelected: boolean;
   childComponents: ChildComponents;
   columns: Column[];
@@ -182,6 +184,7 @@ export interface IHeadRowProps {
   areAllRowsSelected: boolean;
   childComponents: ChildComponents;
   columnReordering?: boolean;
+  columnResizing?: boolean;
   columns: Column[];
   dispatch: DispatchFunc;
   groupColumnsCount: number;


### PR DESCRIPTION
1) columnResizing is a common option for all columns (no need to set isResizable to each column).
2) headCellResize was added to childComponents to give more customization abilities