### PR TITLE
Add pagingSizes & customization improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/src/Demos/CustomPagingDemo/CustomPagingDemo.scss
+++ b/src/Demos/CustomPagingDemo/CustomPagingDemo.scss
@@ -1,0 +1,12 @@
+.custom-paging-demo {
+  .ka{
+    .ka-paging-sizes, .ka-paging-pages{
+      margin: 10px;
+      color: #777;
+
+      .form-control{
+        margin-left: 5px;
+      }
+    }
+  }
+}

--- a/src/Demos/CustomPagingDemo/CustomPagingDemo.test.tsx
+++ b/src/Demos/CustomPagingDemo/CustomPagingDemo.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import CustomPagingDemo from './CustomPagingDemo';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<CustomPagingDemo />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/src/Demos/CustomPagingDemo/CustomPagingDemo.tsx
+++ b/src/Demos/CustomPagingDemo/CustomPagingDemo.tsx
@@ -1,3 +1,5 @@
+import './CustomPagingDemo.scss';
+
 import React, { useState } from 'react';
 
 import { ITableProps, kaReducer, Table } from '../../lib';
@@ -34,7 +36,7 @@ const tableOption: ITableProps = {
 };
 
 const PageSizeSelector: React.FC<IPagingProps> = ({ pageSize, pageSizes, dispatch }) =>  (
-  <div>
+  <div className='ka-paging-sizes'>
     Page Size:
     <select
       className='form-control'
@@ -72,22 +74,24 @@ const CustomPagingDemo: React.FC = () => {
   };
 
   return (
-    <Table
-      {...option}
-      dispatch={dispatch}
-      childComponents={{
-        paging: {
-          content: (props) => {
-            return (
-              <>
-                <PageSizeSelector {...props}/>
-                <PagesSelector {...props}/>
-              </>
-            );
+    <div className='custom-paging-demo'>
+      <Table
+        {...option}
+        dispatch={dispatch}
+        childComponents={{
+          paging: {
+            content: (props) => {
+              return (
+                <>
+                  <PageSizeSelector {...props}/>
+                  <PagesSelector {...props}/>
+                </>
+              );
+            }
           }
-        }
-      }}
-    />
+        }}
+      />
+    </div>
   );
 };
 

--- a/src/Demos/CustomPagingDemo/CustomPagingDemo.tsx
+++ b/src/Demos/CustomPagingDemo/CustomPagingDemo.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+
+import { ITableProps, kaReducer, Table } from '../../lib';
+import { updatePageIndex, updatePageSize } from '../../lib/actionCreators';
+import { DataType } from '../../lib/enums';
+import { IPagingPagesProps, IPagingProps } from '../../lib/props';
+import { DispatchFunc } from '../../lib/types';
+
+const dataArray = Array(180).fill(undefined).map(
+  (_, index) => ({
+    column1: `column:1 row:${index}`,
+    column2: `column:2 row:${index}`,
+    column3: `column:3 row:${index}`,
+    column4: `column:4 row:${index}`,
+    id: index,
+  }),
+);
+
+const tableOption: ITableProps = {
+  columns: [
+    { key: 'column1', title: 'Column 1', dataType: DataType.String },
+    { key: 'column2', title: 'Column 2', dataType: DataType.String },
+    { key: 'column3', title: 'Column 3', dataType: DataType.String },
+    { key: 'column4', title: 'Column 4', dataType: DataType.String },
+  ],
+  data: dataArray,
+  paging: {
+    enabled: true,
+    pageIndex: 0,
+    pageSize: 10,
+    pageSizes: [5, 10, 15]
+  },
+  rowKeyField: 'id',
+};
+
+const PageSizeSelector: React.FC<IPagingProps> = ({ pageSize, pageSizes, dispatch }) =>  (
+  <div>
+    Page Size:
+    <select
+      className='form-control'
+      defaultValue={pageSize}
+      onChange={(event) => {
+        dispatch(updatePageSize(Number(event.currentTarget.value)));
+      }}>
+      {
+        pageSizes?.map((value) => (<option key={value} value={value}>{value}</option>))
+      }
+    </select>
+  </div>
+)
+
+const PagesSelector: React.FC<IPagingPagesProps> = ({ pageIndex, pageSize, dispatch }) =>  (
+  <div className='ka-paging-pages'>
+    Page Number:
+    <select
+      className='form-control'
+      defaultValue={pageIndex}
+      onChange={(event) => {
+        dispatch(updatePageIndex(Number(event.currentTarget.value)));
+      }}>
+      {
+        [...Array(pageSize)].map((_, index) => (<option key={index} value={index}>{index + 1}</option>))
+      }
+    </select>
+  </div>
+)
+
+const CustomPagingDemo: React.FC = () => {
+  const [option, changeOptions] = useState(tableOption);
+  const dispatch: DispatchFunc = (action) => {
+    changeOptions((prevState: ITableProps) => kaReducer(prevState, action));
+  };
+
+  return (
+    <Table
+      {...option}
+      dispatch={dispatch}
+      childComponents={{
+        paging: {
+          content: (props) => {
+            return (
+              <>
+                <PageSizeSelector {...props}/>
+                <PagesSelector {...props}/>
+              </>
+            );
+          }
+        }
+      }}
+    />
+  );
+};
+
+export default CustomPagingDemo;

--- a/src/Demos/Demos.tsx
+++ b/src/Demos/Demos.tsx
@@ -16,6 +16,7 @@ import CustomCellDemo from './CustomCellDemo/CustomCellDemo';
 import CustomDataRowDemo from './CustomDataRowDemo/CustomDataRowDemo';
 import CustomEditorDemo from './CustomEditorDemo/CustomEditorDemo';
 import CustomHeaderCellDemo from './CustomHeaderCellDemo/CustomHeaderCellDemo';
+import CustomPagingDemo from './CustomPagingDemo/CustomPagingDemo';
 import CustomThemeDemo from './CustomThemeDemo/CustomThemeDemo';
 import DeleteRowDemo from './DeleteRowDemo/DeleteRowDemo';
 import Demo from './Demo';
@@ -80,6 +81,7 @@ const demos: Demo[] = [
   new Demo(CustomDataRowDemo, '/custom-data-row', 'Custom Row', 'CustomDataRowDemo', 'https://stackblitz.com/edit/table-custom-data-row-js', 'https://stackblitz.com/edit/table-custom-data-row-ts', 'Customization'),
   new Demo(CustomEditorDemo, '/custom-editor', 'Custom Editor', 'CustomEditorDemo', 'https://stackblitz.com/edit/table-custom-editor-js', 'https://stackblitz.com/edit/table-custom-editor-ts', 'Editing'),
   new Demo(CustomHeaderCellDemo, '/custom-header-cell', 'Custom Header Cell', 'CustomHeaderCellDemo', 'https://stackblitz.com/edit/table-custom-header-cell-js', 'https://stackblitz.com/edit/table-custom-header-cell-ts', 'Customization'),
+  new Demo(CustomPagingDemo, '/custom-paging', 'Custom Paging', 'CustomPagingDemo', 'https://stackblitz.com/edit/table-custom-paging-js', 'https://stackblitz.com/edit/table-custom-paging-ts', 'Customization'),
   new Demo(CustomThemeDemo, '/custom-theme', 'Custom Theme', 'CustomThemeDemo', 'https://stackblitz.com/edit/table-custom-theme-js', 'https://stackblitz.com/edit/table-custom-theme-ts', 'Themes', 'dark.scss'),
   new Demo(DeleteRowDemo, '/delete-row', 'Delete Row', 'DeleteRowDemo', 'https://stackblitz.com/edit/table-delete-row-js', 'https://stackblitz.com/edit/table-delete-row-ts', 'Editing'),
   new Demo(DetailsRowDemo, '/details-row', 'Details Row', 'DetailsRowDemo', 'https://stackblitz.com/edit/table-details-row-js', 'https://stackblitz.com/edit/table-details-row-ts', 'Rows'),

--- a/src/Demos/DemosMenu.tsx
+++ b/src/Demos/DemosMenu.tsx
@@ -39,6 +39,7 @@ const DemosMenu: React.FC<IDemosMenuProps> = ({ cases }) => {
       || c.group.toLowerCase().includes(search.toLowerCase())
       || (synonyms[c.name] && synonyms[c.name].some(t => t.toLowerCase().includes(search.toLowerCase())))
   }) : cases;
+  filteredCases.sort((a, b) => a.title.localeCompare(b.title));
 
   let menuItems: MenuItem[] = [];
   filteredCases.forEach(c => {

--- a/src/Demos/MenuItems.tsx
+++ b/src/Demos/MenuItems.tsx
@@ -11,8 +11,8 @@ export class MenuItem {
   public isActive?: boolean;
 }
 
-const newItems: string[] = ['ResponsiveDemo', 'KeyboardNavigationDemo'];
-const updateItems: string[] = ['Miscellaneous'];
+const newItems: string[] = ['ResponsiveDemo', 'KeyboardNavigationDemo', 'CustomPagingDemo'];
+const updateItems: string[] = ['Miscellaneous', 'Customization', 'PagingDemo'];
 
 const MenuItems: React.FC<{ items: MenuItem[] }> = ({ items }) => {
 

--- a/src/Demos/PagingDemo/PagingDemo.tsx
+++ b/src/Demos/PagingDemo/PagingDemo.tsx
@@ -26,6 +26,7 @@ const tableOption: ITableProps = {
     enabled: true,
     pageIndex: 0,
     pageSize: 10,
+    pageSizes: [5, 10, 15]
   },
   rowKeyField: 'id',
 };

--- a/src/lib/Components/HeadRow/HeadRow.test.tsx
+++ b/src/lib/Components/HeadRow/HeadRow.test.tsx
@@ -1,8 +1,12 @@
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { DataType } from '../../enums';
 import HeaderRow from './HeadRow';
+
+Enzyme.configure({ adapter: new Adapter() });
 
 const props: any = {
   childComponents: {},
@@ -17,3 +21,17 @@ it('renders without crashing', () => {
   ReactDOM.render(<HeaderRow {...props} />, element);
   ReactDOM.unmountComponentAtNode(element);
 });
+
+it('should handle onMouseDown correctly', () => {
+  const wrapper = mount((
+    <HeaderRow {...props} childComponents={{
+      headRow: {
+        content: () => <td>Custom</td>
+      }
+    }} />
+  ), {
+    attachTo: document.createElement('thead')
+  });
+  expect(wrapper.find('td').text()).toBe('Custom');
+});
+

--- a/src/lib/Components/HeadRow/HeadRow.tsx
+++ b/src/lib/Components/HeadRow/HeadRow.tsx
@@ -2,36 +2,52 @@ import React from 'react';
 
 import defaultOptions from '../../defaultOptions';
 import { IHeadRowProps } from '../../props';
+import { getElementCustomization } from '../../Utils/ComponentUtils';
 import EmptyCells from '../EmptyCells/EmptyCells';
 import HeadCell from '../HeadCell/HeadCell';
 
-const HeadRow: React.FunctionComponent<IHeadRowProps> = ({
-  areAllRowsSelected,
-  childComponents,
-  columnReordering,
-  columnResizing,
-  columns,
-  dispatch,
-  groupColumnsCount,
-  sortingMode,
-}) => (
-  <tr className={defaultOptions.css.theadRow}>
-    <EmptyCells count={groupColumnsCount} isTh={true}/>
-    {columns.map((column) => {
-      return (
-        <HeadCell
-          areAllRowsSelected={areAllRowsSelected}
-          childComponents={childComponents}
-          columnReordering={columnReordering}
-          columnResizing={columnResizing}
-          column={column}
-          dispatch={dispatch}
-          key={column.key}
-          sortingMode={sortingMode}
-        />
-      );
-    })}
-  </tr>
-);
+const HeadRow: React.FunctionComponent<IHeadRowProps> = (props) => {
+  const {
+    areAllRowsSelected,
+    childComponents,
+    columnReordering,
+    columnResizing,
+    columns,
+    dispatch,
+    groupColumnsCount,
+    sortingMode
+  } = props;
+  const { elementAttributes, content } = getElementCustomization({
+    className: defaultOptions.css.theadRow
+  }, props, childComponents.headRow);
+  return (
+    <tr {...elementAttributes}>
+      {
+        content ||
+        (
+          <>
+            <EmptyCells count={groupColumnsCount} isTh={true} />
+            {
+              columns.map((column) => {
+                return (
+                  <HeadCell
+                    areAllRowsSelected={areAllRowsSelected}
+                    childComponents={childComponents}
+                    columnReordering={columnReordering}
+                    columnResizing={columnResizing}
+                    column={column}
+                    dispatch={dispatch}
+                    key={column.key}
+                    sortingMode={sortingMode}
+                  />
+                );
+              })
+            }
+          </>
+        )
+      }
+    </tr>
+  );
+};
 
 export default HeadRow;

--- a/src/lib/Components/Paging/Paging.test.tsx
+++ b/src/lib/Components/Paging/Paging.test.tsx
@@ -1,4 +1,4 @@
-import Enzyme from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -20,4 +20,16 @@ it('renders without crashing', () => {
   const element = document.createElement('div');
   ReactDOM.render(<Paging {...props} />, element);
   ReactDOM.unmountComponentAtNode(element);
+});
+it('should be rendered with PagingSizes', () => {
+  const wrapper = mount(<Paging {...props} pageSizes={[5, 10, 15]}/>);
+  expect(wrapper.find('.ka-paging-sizes').exists()).toBeTruthy();
+});
+it('should be rendered without PagingSizes', () => {
+  const wrapper = mount(<Paging {...props} pageSizes={undefined}/>);
+  expect(wrapper.find('.ka-paging-sizes').exists()).toBeFalsy();
+});
+it('should render with custom content', () => {
+  const wrapper = mount(<Paging {...props} childComponents={{ paging: { content: () => (<>Custom Paging</>) }}} />);
+  expect(wrapper.find('.ka-paging').text()).toEqual('Custom Paging');
 });

--- a/src/lib/Components/Paging/Paging.tsx
+++ b/src/lib/Components/Paging/Paging.tsx
@@ -2,18 +2,21 @@ import * as React from 'react';
 
 import defaultOptions from '../../defaultOptions';
 import { IPagingProps } from '../../props';
+import { getElementCustomization } from '../../Utils/ComponentUtils';
 import PagingPages from '../PagingPages/PagingPages';
 
 const Paging: React.FunctionComponent<IPagingProps> = (props) => {
     const {
       enabled,
-      pagesCount,
+      childComponents,
     } = props;
     if (enabled){
-      const pages = new Array(pagesCount).fill(undefined).map((_, index) =>  index);
+      const { elementAttributes, content } = getElementCustomization({
+        className: defaultOptions.css.paging,
+      }, props, childComponents.paging);
       return (
-        <div className={defaultOptions.css.paging}>
-          <PagingPages {...props} pages={pages}/>
+        <div {...elementAttributes}>
+          {content || <PagingPages {...props}/>}
         </div>
       )
     }

--- a/src/lib/Components/Paging/Paging.tsx
+++ b/src/lib/Components/Paging/Paging.tsx
@@ -4,19 +4,27 @@ import defaultOptions from '../../defaultOptions';
 import { IPagingProps } from '../../props';
 import { getElementCustomization } from '../../Utils/ComponentUtils';
 import PagingPages from '../PagingPages/PagingPages';
+import PagingSizes from '../PagingSizes/PagingSizes';
 
 const Paging: React.FunctionComponent<IPagingProps> = (props) => {
     const {
       enabled,
       childComponents,
+      pageSizes
     } = props;
     if (enabled){
       const { elementAttributes, content } = getElementCustomization({
-        className: defaultOptions.css.paging,
+        className: `${defaultOptions.css.paging} ${pageSizes ? 'ka-paging-sizes-active' : ''}`,
       }, props, childComponents.paging);
       return (
         <div {...elementAttributes}>
-          {content || <PagingPages {...props}/>}
+          {content ||
+          (
+            <>
+              {pageSizes && <PagingSizes {...props}/>}
+              <PagingPages {...props}/>
+            </>
+          )}
         </div>
       )
     }

--- a/src/lib/Components/PagingIndex/PagingIndex.test.tsx
+++ b/src/lib/Components/PagingIndex/PagingIndex.test.tsx
@@ -1,8 +1,9 @@
-import Enzyme from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { ActionType } from '../../enums';
 import PagingIndex, { IPagingIndexProps } from './PagingIndex';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -15,4 +16,15 @@ it('renders without crashing', () => {
   const element = document.createElement('div');
   ReactDOM.render(<PagingIndex {...props} />, element);
   ReactDOM.unmountComponentAtNode(element);
+});
+
+it('onClick should dispath UpdatePageIndex on click', () => {
+  const dispatch = jest.fn();
+  const wrapper = mount(<PagingIndex {...props} pageIndex={2} dispatch={dispatch} />);
+  wrapper.find('.ka-paging-page-index').first().simulate('click');
+  expect(dispatch).toBeCalledTimes(1);
+  expect(dispatch).toBeCalledWith({
+    pageIndex: 2,
+    type: ActionType.UpdatePageIndex,
+  });
 });

--- a/src/lib/Components/PagingPages/PagingPages.tsx
+++ b/src/lib/Components/PagingPages/PagingPages.tsx
@@ -13,7 +13,7 @@ const PagingPages: React.FunctionComponent<IPagingPagesProps> = (props) => {
       dispatch,
       pagesCount,
       pageIndex = 0,
-      pages = getPagesArrayBySize(pagesCount), // TODO: deprecate
+      pages = getPagesArrayBySize(pagesCount),
     } = props;
 
     React.useEffect(() => {

--- a/src/lib/Components/PagingPages/PagingPages.tsx
+++ b/src/lib/Components/PagingPages/PagingPages.tsx
@@ -4,17 +4,16 @@ import { updatePageIndex } from '../../actionCreators';
 import defaultOptions from '../../defaultOptions';
 import { IPagingPagesProps } from '../../props';
 import { getElementCustomization } from '../../Utils/ComponentUtils';
-import { centerLength, getPagesForCenter } from '../../Utils/PagingUtils';
+import { centerLength, getPagesArrayBySize, getPagesForCenter } from '../../Utils/PagingUtils';
 import PagingIndex from '../PagingIndex/PagingIndex';
 
 const PagingPages: React.FunctionComponent<IPagingPagesProps> = (props) => {
     const {
       childComponents,
-      pages,
       dispatch,
-    } = props;
-    const {
+      pagesCount,
       pageIndex = 0,
+      pages = getPagesArrayBySize(pagesCount), // TODO: deprecate
     } = props;
 
     React.useEffect(() => {

--- a/src/lib/Components/PagingSize/PagingSize.test.tsx
+++ b/src/lib/Components/PagingSize/PagingSize.test.tsx
@@ -3,6 +3,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { ActionType } from '../../enums';
 import { IPagingSizeProps } from '../../props';
 import PagingSize from './PagingSize';
 
@@ -10,7 +11,7 @@ Enzyme.configure({ adapter: new Adapter() });
 
 const props: IPagingSizeProps = {
   childComponents: {},
-  value: 1
+  value: 5
 };
 
 it('renders without crashing', () => {
@@ -21,4 +22,15 @@ it('renders without crashing', () => {
 it('should render with custom content', () => {
   const wrapper = mount(<PagingSize {...props} childComponents={{ pagingSize: { content: () => (<>Custom Paging Size</>) }}} />);
   expect(wrapper.find('.ka-paging-size').text()).toEqual('Custom Paging Size');
+});
+
+it('onClick should dispath UpdatePageSize on click', () => {
+  const dispatch = jest.fn();
+  const wrapper = mount(<PagingSize {...props} dispatch={dispatch} />);
+  wrapper.find('.ka-paging-size').first().simulate('click');
+  expect(dispatch).toBeCalledTimes(1);
+  expect(dispatch).toBeCalledWith({
+    pageSize: 5,
+    type: ActionType.UpdatePageSize,
+  });
 });

--- a/src/lib/Components/PagingSize/PagingSize.test.tsx
+++ b/src/lib/Components/PagingSize/PagingSize.test.tsx
@@ -1,19 +1,24 @@
-import Enzyme from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { IPagingIndexProps } from '../../props';
+import { IPagingSizeProps } from '../../props';
 import PagingSize from './PagingSize';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const props: IPagingIndexProps = {
+const props: IPagingSizeProps = {
   childComponents: {},
+  value: 1
 };
 
 it('renders without crashing', () => {
   const element = document.createElement('div');
   ReactDOM.render(<PagingSize {...props} />, element);
   ReactDOM.unmountComponentAtNode(element);
+});
+it('should render with custom content', () => {
+  const wrapper = mount(<PagingSize {...props} childComponents={{ pagingSize: { content: () => (<>Custom Paging Size</>) }}} />);
+  expect(wrapper.find('.ka-paging-size').text()).toEqual('Custom Paging Size');
 });

--- a/src/lib/Components/PagingSize/PagingSize.test.tsx
+++ b/src/lib/Components/PagingSize/PagingSize.test.tsx
@@ -1,0 +1,19 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { IPagingIndexProps } from '../../props';
+import PagingSize from './PagingSize';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const props: IPagingIndexProps = {
+  childComponents: {},
+};
+
+it('renders without crashing', () => {
+  const element = document.createElement('div');
+  ReactDOM.render(<PagingSize {...props} />, element);
+  ReactDOM.unmountComponentAtNode(element);
+});

--- a/src/lib/Components/PagingSize/PagingSize.tsx
+++ b/src/lib/Components/PagingSize/PagingSize.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { updatePageSize } from '../../actionCreators';
+import defaultOptions from '../../defaultOptions';
+import { IPagingSizeProps } from '../../props';
+import { getElementCustomization } from '../../Utils/ComponentUtils';
+
+const PagingSize: React.FunctionComponent<IPagingSizeProps> = (props) => {
+  const {
+    childComponents,
+    dispatch,
+    pageSize,
+    value
+  } = props;
+  const isActive = pageSize === value;
+  const { elementAttributes, content } = getElementCustomization({
+    className: `${defaultOptions.css.pagingSize} ${isActive ? 'ka-paging-size-active' : ''}`,
+    onClick: () => dispatch(updatePageSize(value))
+  }, props, childComponents.pagingSize);
+  return  (
+    <li
+      {...elementAttributes}>
+        {content || value}
+    </li>
+  );
+};
+
+export default PagingSize;

--- a/src/lib/Components/PagingSizes/PagingSizes.test.tsx
+++ b/src/lib/Components/PagingSizes/PagingSizes.test.tsx
@@ -1,0 +1,30 @@
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { ActionType } from '../../enums';
+import { IPagingPagesProps } from '../../props';
+import PagingSizes from './PagingSizes';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const props: IPagingPagesProps = {
+    pages: [1, 2, 3],
+    pageSize: 2,
+    pageIndex: 2,
+    enabled: true,
+    dispatch: jest.fn(),
+    childComponents: {}
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('renders without crashing', () => {
+  const element = document.createElement('div');
+  ReactDOM.render(<PagingSizes {...props} />, element);
+  ReactDOM.unmountComponentAtNode(element);
+  expect(props.dispatch).toHaveBeenCalledTimes(0);
+});

--- a/src/lib/Components/PagingSizes/PagingSizes.test.tsx
+++ b/src/lib/Components/PagingSizes/PagingSizes.test.tsx
@@ -28,3 +28,8 @@ it('renders without crashing', () => {
   ReactDOM.unmountComponentAtNode(element);
   expect(props.dispatch).toHaveBeenCalledTimes(0);
 });
+it('should be rendered without PagingSizes', () => {
+  const wrapper = mount(<PagingSizes {...props} childComponents={{ pagingSizes: { content: () => (<>Custom Paging Sizes</>) }}} />);
+  expect(wrapper.find('.ka-paging-sizes').text()).toEqual('Custom Paging Sizes');
+});
+

--- a/src/lib/Components/PagingSizes/PagingSizes.tsx
+++ b/src/lib/Components/PagingSizes/PagingSizes.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import defaultOptions from '../../defaultOptions';
+import { IPagingProps } from '../../props';
+import { getElementCustomization } from '../../Utils/ComponentUtils';
+import PagingSizeItem from '../PagingSize/PagingSize';
+
+const PagingSizes: React.FunctionComponent<IPagingProps> = (props) => {
+    const {
+      childComponents,
+      pageSizes = [],
+    } = props;
+
+    const { elementAttributes, content } = getElementCustomization({
+      className: defaultOptions.css.pagingSizes
+    }, props, childComponents.pagingSizes);
+
+    return (
+      <ul {...elementAttributes}>
+        { content || (
+          pageSizes.map(value => <PagingSizeItem {...props} key={value} value={value}/>)
+        )}
+      </ul>
+    )
+}
+
+export default PagingSizes;

--- a/src/lib/Models/ChildComponents.ts
+++ b/src/lib/Models/ChildComponents.ts
@@ -1,8 +1,8 @@
 import { ITableProps } from '../';
 import {
   ICellEditorProps, ICellProps, ICellTextProps, IDataRowProps, IFilterRowEditorProps,
-  IGroupRowProps, IHeadCellProps, IHeadCellResizeProps, INoDataRowProps, IPagingIndexProps,
-  IPagingPagesProps, ITableBodyProps, ITableHeadProps,
+  IGroupRowProps, IHeadCellProps, IHeadCellResizeProps, IHeadRowProps, INoDataRowProps,
+  IPagingIndexProps, IPagingPagesProps, ITableBodyProps, ITableHeadProps,
 } from '../props';
 import { ChildComponent } from './ChildComponent';
 
@@ -19,6 +19,7 @@ export class ChildComponents {
   public groupCell?: ChildComponent<IGroupRowProps>;
   public groupRow?: ChildComponent<IGroupRowProps>;
   public headCell?: ChildComponent<IHeadCellProps>;
+  public headRow?: ChildComponent<IHeadRowProps>;
   public headCellContent?: ChildComponent<IHeadCellProps>;
   public noDataRow?: ChildComponent<INoDataRowProps>;
   public rootDiv?: ChildComponent<ITableProps>;

--- a/src/lib/Models/ChildComponents.ts
+++ b/src/lib/Models/ChildComponents.ts
@@ -2,7 +2,8 @@ import { ITableProps } from '../';
 import {
   ICellEditorProps, ICellProps, ICellTextProps, IDataRowProps, IFilterRowEditorProps,
   IGroupRowProps, IHeadCellProps, IHeadCellResizeProps, IHeadRowProps, INoDataRowProps,
-  IPagingIndexProps, IPagingPagesProps, IPagingProps, ITableBodyProps, ITableHeadProps,
+  IPagingIndexProps, IPagingPagesProps, IPagingProps, IPagingSizeProps, ITableBodyProps,
+  ITableHeadProps,
 } from '../props';
 import { ChildComponent } from './ChildComponent';
 
@@ -24,6 +25,8 @@ export class ChildComponents {
   public paging?: ChildComponent<IPagingProps>;
   public pagingIndex?: ChildComponent<IPagingIndexProps>;
   public pagingPages?: ChildComponent<IPagingPagesProps>;
+  public pagingSize?: ChildComponent<IPagingSizeProps>;
+  public pagingSizes?: ChildComponent<IPagingProps>;
   public rootDiv?: ChildComponent<ITableProps>;
   public table?: ChildComponent<ITableProps>;
   public tableBody?: ChildComponent<ITableBodyProps>;

--- a/src/lib/Models/ChildComponents.ts
+++ b/src/lib/Models/ChildComponents.ts
@@ -2,7 +2,7 @@ import { ITableProps } from '../';
 import {
   ICellEditorProps, ICellProps, ICellTextProps, IDataRowProps, IFilterRowEditorProps,
   IGroupRowProps, IHeadCellProps, IHeadCellResizeProps, IHeadRowProps, INoDataRowProps,
-  IPagingIndexProps, IPagingPagesProps, ITableBodyProps, ITableHeadProps,
+  IPagingIndexProps, IPagingPagesProps, IPagingProps, ITableBodyProps, ITableHeadProps,
 } from '../props';
 import { ChildComponent } from './ChildComponent';
 
@@ -14,18 +14,19 @@ export class ChildComponents {
   public dataRow?: ChildComponent<IDataRowProps>;
   public detailsRow?: ChildComponent<IDataRowProps>;
   public filterRowCell?: ChildComponent<IFilterRowEditorProps>;
-  public pagingIndex?: ChildComponent<IPagingIndexProps>;
-  public pagingPages?: ChildComponent<IPagingPagesProps>;
   public groupCell?: ChildComponent<IGroupRowProps>;
   public groupRow?: ChildComponent<IGroupRowProps>;
   public headCell?: ChildComponent<IHeadCellProps>;
-  public headRow?: ChildComponent<IHeadRowProps>;
   public headCellContent?: ChildComponent<IHeadCellProps>;
+  public headCellResize?: ChildComponent<IHeadCellResizeProps>;
+  public headRow?: ChildComponent<IHeadRowProps>;
   public noDataRow?: ChildComponent<INoDataRowProps>;
+  public paging?: ChildComponent<IPagingProps>;
+  public pagingIndex?: ChildComponent<IPagingIndexProps>;
+  public pagingPages?: ChildComponent<IPagingPagesProps>;
   public rootDiv?: ChildComponent<ITableProps>;
   public table?: ChildComponent<ITableProps>;
   public tableBody?: ChildComponent<ITableBodyProps>;
   public tableHead?: ChildComponent<ITableHeadProps>;
   public tableWrapper?: ChildComponent<ITableProps>;
-  public headCellResize?: ChildComponent<IHeadCellResizeProps>;
 }

--- a/src/lib/Models/CssClasses.ts
+++ b/src/lib/Models/CssClasses.ts
@@ -28,6 +28,8 @@ export class CssClasses {
   public paging = 'ka-paging';
   public pagingPages = 'ka-paging-pages';
   public pagingPageIndex = 'ka-paging-page-index';
+  public pagingSize = 'ka-paging-size';
+  public pagingSizes = 'ka-paging-sizes';
 
   public iconClose = 'ka-icon ka-icon-close';
   public iconGroupArrowCollapsed = 'ka-icon ka-icon-group-arrow ka-icon-group-arrow-collapsed';

--- a/src/lib/Models/Paging.ts
+++ b/src/lib/Models/Paging.ts
@@ -2,5 +2,6 @@ export class PagingOptions {
   enabled?: boolean;
   pageIndex?: number;
   pageSize?: number;
+  pageSizes?: number[];
   pagesCount?: number;
 }

--- a/src/lib/Reducers/kaReducer.ts
+++ b/src/lib/Reducers/kaReducer.ts
@@ -119,6 +119,9 @@ const kaReducer: any = (props: ITableProps, action: any): ITableProps => {
     case ActionType.UpdatePageIndex: {
       return { ...props, paging: {...paging, pageIndex: action.pageIndex } };
     }
+    case ActionType.UpdatePageSize: {
+      return { ...props, paging: {...paging, pageSize: action.pageSize } };
+    }
     case ActionType.UpdatePagesCount: {
       return { ...props, paging: {...paging, pagesCount: action.pagesCount }};
     }

--- a/src/lib/Utils/PagingUtils.test.ts
+++ b/src/lib/Utils/PagingUtils.test.ts
@@ -1,5 +1,5 @@
 import { PagingOptions } from '../models';
-import { getPageData, getPagesCount, getPagesForCenter } from './PagingUtils';
+import { getPageData, getPagesArrayBySize, getPagesCount, getPagesForCenter } from './PagingUtils';
 
 describe('PagingUtils', () => {
   it('getPagesCount', () => {
@@ -153,5 +153,9 @@ describe('PagingUtils', () => {
     expect(result.length).toEqual(5);
     expect(result[0]).toEqual(7);
     expect(result[4]).toEqual(11);
+  });
+  it('getPagesArrayBySize', () => {
+    const result = getPagesArrayBySize(3);
+    expect(result).toEqual([0, 1, 2]);
   });
 });

--- a/src/lib/Utils/PagingUtils.ts
+++ b/src/lib/Utils/PagingUtils.ts
@@ -32,3 +32,5 @@ export const getPagesForCenter = (pages: number[], isStartShown: boolean, isEndS
   }
   return pages;
 };
+
+export const getPagesArrayBySize = (pagesCount?: number) => new Array(pagesCount).fill(undefined).map((_, index) =>  index);

--- a/src/lib/actionCreators.ts
+++ b/src/lib/actionCreators.ts
@@ -175,6 +175,11 @@ export const updatePageIndex = (pageIndex: number) => ({
   type: ActionType.UpdatePageIndex,
 });
 
+export const updatePageSize = (pageSize: number) => ({
+  pageSize,
+  type: ActionType.UpdatePageSize,
+});
+
 export const updatePagesCount = (pagesCount: number) => ({
   pagesCount,
   type: ActionType.UpdatePagesCount,

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -59,6 +59,7 @@ export enum ActionType {
   UpdateFilterRowValue = 'UpdateFilterRowValue',
   UpdateGroupsExpanded = 'UpdateGroupsExpanded',
   UpdatePageIndex = 'UpdatePageIndex',
+  UpdatePageSize = 'UpdatePageSize',
   UpdatePagesCount = 'UpdatePagesCount',
   UpdateRow = 'UpdateRow',
   UpdateSortDirection = 'UpdateSortDirection',

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -203,12 +203,13 @@ export interface ILoadingProps {
 }
 
 export interface IPagingProps {
+  childComponents: ChildComponents;
+  dispatch: DispatchFunc;
   enabled?: boolean;
   pageIndex?: number;
   pageSize?: number;
+  pageSizes?: number[];
   pagesCount?: number;
-  childComponents: ChildComponents;
-  dispatch: DispatchFunc;
 }
 
 export interface IPagingIndexProps extends IPagingProps {
@@ -217,5 +218,5 @@ export interface IPagingIndexProps extends IPagingProps {
   text: any;
 }
 export interface IPagingPagesProps extends IPagingProps {
-  pages: number[];
+  pages?: number[];
 }

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -211,12 +211,17 @@ export interface IPagingProps {
   pageSizes?: number[];
   pagesCount?: number;
 }
+export interface IPagingSizeProps extends IPagingProps {
+  value: number;
+}
 
 export interface IPagingIndexProps extends IPagingProps {
   isActive: boolean;
   pageIndex: number;
   text: any;
 }
+
 export interface IPagingPagesProps extends IPagingProps {
-  pages?: number[];
+  pages?: number[]; // TODO: will be deprecated next major release
 }
+

--- a/src/lib/style.scss
+++ b/src/lib/style.scss
@@ -199,16 +199,24 @@
   color: $ka-color-base;
 }
 
-.ka-paging-pages{
+.ka-paging-sizes-active {
+  display: flex;
+  justify-content: space-between;
+}
+
+.ka-paging-pages, .ka-paging-sizes {
   list-style: none;
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
   padding: $ka-paging-pages-padding;
   margin: $ka-paging-pages-margin;
 }
 
-.ka-paging-page-index{
+.ka-paging-pages {
+  justify-content: flex-end;
+}
+
+.ka-paging-page-index, .ka-paging-size{
   cursor: pointer;
   padding: 5px;
   margin: 10px 5px;
@@ -219,7 +227,7 @@
   user-select: none;
 }
 
-.ka-paging-page-index-active{
+.ka-paging-page-index-active, .ka-paging-size-active {
   background-color: $ka-paging-index-active-background-color;
   font-weight: bold;
   color: $ka-paging-index-active-color;


### PR DESCRIPTION
new childComponents:
- headRow
- paging
- pagingSize
- pagingSizes

new option 
paging.pageSizes: number[]; - sets available values for pageSize selector
![image](https://user-images.githubusercontent.com/17903747/106368608-45391d00-634b-11eb-99b5-9d7bfd19ebe8.png)

Paging Demo: https://komarovalexander.github.io/ka-table/#/paging
Custom Paging Demo: https://komarovalexander.github.io/ka-table/#/custom-paging