### PR TITLE
Make headerFilterButton customizable by childComponents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "7.3.5",
+  "version": "7.4.0",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/src/Demos/HeaderFilterDemo/HeaderFilterDemo.tsx
+++ b/src/Demos/HeaderFilterDemo/HeaderFilterDemo.tsx
@@ -58,7 +58,7 @@ const HeaderFilterDemo: React.FC = () => {
       dispatch={dispatch}
       childComponents={{
         headFilterButton: {
-          content: ({ column: {key}}) => key === 'name' && <></>, // hide the header filter for 'nextTry' column
+          content: ({ column: {key}}) => key === 'name' && <></>,
         },
       }}
     />

--- a/src/Demos/HeaderFilterDemo/HeaderFilterDemo.tsx
+++ b/src/Demos/HeaderFilterDemo/HeaderFilterDemo.tsx
@@ -56,6 +56,11 @@ const HeaderFilterDemo: React.FC = () => {
       {...tableProps}
       data={dataArray}
       dispatch={dispatch}
+      childComponents={{
+        headFilterButton: {
+          content: ({ column: {key}}) => key === 'name' && <></>, // hide the header filter for 'nextTry' column
+        },
+      }}
     />
   );
 };

--- a/src/lib/Components/HeadCellContent/HeadCellContent.tsx
+++ b/src/lib/Components/HeadCellContent/HeadCellContent.tsx
@@ -15,7 +15,7 @@ const HeadCellContent: React.FunctionComponent<IHeadCellProps> = (props) => {
     dispatch,
     sortingMode,
     filteringMode,
-    childComponents: { headCellContent },
+    childComponents,
   } = props;
   const sortingEnabled = isSortingEnabled(sortingMode);
   const onClick = sortingEnabled ? () => {
@@ -25,7 +25,7 @@ const HeadCellContent: React.FunctionComponent<IHeadCellProps> = (props) => {
   const { elementAttributes, content } = getElementCustomization({
     className: `${defaultOptions.css.theadCellContent} ${sortingEnabled ? 'ka-pointer' : ''}`,
     onClick
-  }, props, headCellContent);
+  }, props, childComponents.headCellContent);
 
 
   const refToElement = React.useRef<HTMLDivElement>(null);
@@ -51,6 +51,7 @@ const HeadCellContent: React.FunctionComponent<IHeadCellProps> = (props) => {
           <HeaderFilterButton
             column={column}
             dispatch={dispatch}
+            childComponents={childComponents}
           />
         )
         }

--- a/src/lib/Components/HeaderFilterButton/HeaderFilterButton.test.tsx
+++ b/src/lib/Components/HeaderFilterButton/HeaderFilterButton.test.tsx
@@ -6,11 +6,12 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import { ActionType } from '../../enums';
 import { Column } from '../../models';
-import HeaderFilterButton, { HeaderFilterButtonProps } from './HeaderFilterButton';
+import { IHeaderFilterButtonProps } from '../../props';
+import HeaderFilterButton from './HeaderFilterButton';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const props: HeaderFilterButtonProps = {
+const props: IHeaderFilterButtonProps = {
     column: new Column(),
     dispatch: jest.fn()
 };

--- a/src/lib/Components/HeaderFilterButton/HeaderFilterButton.tsx
+++ b/src/lib/Components/HeaderFilterButton/HeaderFilterButton.tsx
@@ -2,21 +2,26 @@ import * as React from 'react';
 
 import { updateHeaderFilterPopupState } from '../../actionCreators';
 import defaultOptions from '../../defaultOptions';
-import { Column } from '../../models';
-import { DispatchFunc } from '../../types';
+import { IHeaderFilterButtonProps } from '../../props';
+import { getElementCustomization } from '../../Utils/ComponentUtils';
 
-export interface HeaderFilterButtonProps {
-  column: Column,
-  dispatch: DispatchFunc
-}
-
-const HeaderFilterButton: React.FC<HeaderFilterButtonProps> = ({ column, dispatch }) => (
-  <span
-    onClick={(event: React.SyntheticEvent<HTMLSpanElement>) => {
+const HeaderFilterButton: React.FC<IHeaderFilterButtonProps> = (props) => {
+  const { childComponents, column, dispatch } = props;
+  const { elementAttributes, content } = getElementCustomization({
+    className: `ka-header-filter-button ${column.headerFilterValues?.length ? 'ka-header-filter-button-has-value' : ''}`,
+    onClick: (event: React.SyntheticEvent<HTMLSpanElement>) => {
       event.stopPropagation();
       dispatch(updateHeaderFilterPopupState(column.key, !column.isHeaderFilterPopupShown))
-    }}
-    className={`${defaultOptions.css.iconFilter} ka-header-filter-button ${column.headerFilterValues?.length ? 'ka-header-filter-button-has-value' : ''}`}/>
-);
+    }
+  }, props, childComponents?.headFilterButton);
+  return (
+    <span {...elementAttributes}>
+      {content || (
+        <span
+          className={`${defaultOptions.css.iconFilter} ka-header-filter-button-icon`}/>
+      )}
+    </span>
+  )
+};
 
 export default HeaderFilterButton;

--- a/src/lib/Models/ChildComponents.ts
+++ b/src/lib/Models/ChildComponents.ts
@@ -2,9 +2,9 @@ import { ITableProps } from '../';
 import {
   ICellEditorProps, ICellProps, ICellTextProps, IDataRowProps, IFilterRowEditorProps,
   IGroupRowProps, IGroupSummaryCellProps, IGroupSummaryRowProps, IHeadCellProps,
-  IHeadCellResizeProps, IHeadRowProps, INoDataRowProps, IPagingIndexProps, IPagingProps,
-  IPagingSizeProps, IPopupContentItemProps, IPopupContentProps, ISummaryCellProps, ISummaryRowProps,
-  ITableBodyProps, ITableFootProps, ITableHeadProps,
+  IHeadCellResizeProps, IHeaderFilterButtonProps, IHeadRowProps, INoDataRowProps, IPagingIndexProps,
+  IPagingProps, IPagingSizeProps, IPopupContentItemProps, IPopupContentProps, ISummaryCellProps,
+  ISummaryRowProps, ITableBodyProps, ITableFootProps, ITableHeadProps,
 } from '../props';
 import { ChildComponent } from './ChildComponent';
 
@@ -20,6 +20,7 @@ export class ChildComponents {
   public groupRow?: ChildComponent<IGroupRowProps>;
   public groupSummaryRow?: ChildComponent<IGroupSummaryRowProps>;
   public groupSummaryCell?: ChildComponent<IGroupSummaryCellProps>;
+  public headFilterButton?: ChildComponent<IHeaderFilterButtonProps>;
   public headCell?: ChildComponent<IHeadCellProps>;
   public headCellContent?: ChildComponent<IHeadCellProps>;
   public headCellResize?: ChildComponent<IHeadCellResizeProps>;

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -284,3 +284,9 @@ export interface IPopupProps {
   dispatch: DispatchFunc;
   format?: FormatFunc;
 }
+
+export interface IHeaderFilterButtonProps {
+  childComponents?: ChildComponents;
+  column: Column,
+  dispatch: DispatchFunc
+}

--- a/src/lib/style.scss
+++ b/src/lib/style.scss
@@ -300,8 +300,11 @@
   padding: $ka-cell-padding;
 }
 
-.ka-header-filter-button{
+.ka-header-filter-button-icon{
   font-size: 16px;
+}
+
+.ka-header-filter-button{
   margin-left: 3px;
 }
 


### PR DESCRIPTION
#223 

headFilterButton was added to childComponents

```
      childComponents={{
        headFilterButton: {
          content: ({ column: {key}}) => key === 'name' && <></>,
        },
      }}
```

demo: https://komarovalexander.github.io/ka-table/#/header-filter