### PR TITLE
Add treeExpandButtonColumnKey option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "7.7.1",
+  "version": "7.7.0",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "7.6.4",
+  "version": "7.7.1",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/src/Demos/TreeModeDemo/TreeModeDemo.tsx
+++ b/src/Demos/TreeModeDemo/TreeModeDemo.tsx
@@ -27,7 +27,6 @@ const tablePropsInit: ITableProps = {
   ],
   data,
   filteringMode: FilteringMode.FilterRow,
-  treeExpandButtonColumnKey: 'productivity',
   treeGroupKeyField: 'treeGroupId',
   editingMode: EditingMode.Cell,
   treeGroupsExpanded: [7, 11],

--- a/src/Demos/TreeModeDemo/TreeModeDemo.tsx
+++ b/src/Demos/TreeModeDemo/TreeModeDemo.tsx
@@ -27,6 +27,7 @@ const tablePropsInit: ITableProps = {
   ],
   data,
   filteringMode: FilteringMode.FilterRow,
+  treeExpandButtonColumnKey: 'productivity',
   treeGroupKeyField: 'treeGroupId',
   editingMode: EditingMode.Cell,
   treeGroupsExpanded: [7, 11],

--- a/src/lib/Components/DataRowContent/DataRowContent.tsx
+++ b/src/lib/Components/DataRowContent/DataRowContent.tsx
@@ -25,14 +25,15 @@ const DataRowContent: React.FunctionComponent<IDataRowProps> = ({
   rowKeyValue,
   selectedRows,
   validation,
+  treeExpandButtonColumnKey
 }) => {
-  const arrow = isTreeGroup ? [(
+  const arrow = isTreeGroup ? (
     <div
       onClick={() => dispatch(updateTreeGroupsExpanded(rowKeyValue))}
       className={isTreeExpanded
         ? defaultOptions.css.iconTreeArrowExpanded : defaultOptions.css.iconTreeArrowCollapsed}
     />
-  )] : undefined;
+  ) : undefined;
   return (
     <>
       {columns.map((column, index) => {
@@ -40,10 +41,11 @@ const DataRowContent: React.FunctionComponent<IDataRowProps> = ({
         const hasEditorValue = editableCell && editableCell.hasOwnProperty('editorValue');
         const editorValue = editableCell && editableCell.editorValue;
         const value = hasEditorValue ? editorValue : getValueByColumn(rowData, column);
-        const cellDeep = treeDeep != null && index === 0 ? treeDeep : undefined;
+        const isTreeColumn = treeExpandButtonColumnKey ? treeExpandButtonColumnKey === column.key : index === 0;
+        const cellDeep = treeDeep != null && isTreeColumn ? treeDeep : undefined;
         return (
           <CellComponent
-            treeArrowElement={arrow?.pop()}
+            treeArrowElement={isTreeColumn && arrow}
             childComponents={childComponents}
             treeDeep={cellDeep}
             column={column}

--- a/src/lib/Components/Rows/Rows.tsx
+++ b/src/lib/Components/Rows/Rows.tsx
@@ -32,6 +32,7 @@ const Rows: React.FunctionComponent<IRowsProps> = (props) => {
     rowReordering,
     selectedRows,
     validation,
+    treeExpandButtonColumnKey
   } = props;
   const groupMark = getGroupMark();
 
@@ -83,6 +84,7 @@ const Rows: React.FunctionComponent<IRowsProps> = (props) => {
             isTreeGroup={isTreeGroup}
             isTreeExpanded={isTreeExpanded}
             treeDeep={isTreeRow === true ? d.treeDeep : undefined}
+            treeExpandButtonColumnKey={treeExpandButtonColumnKey}
             format={format}
             groupColumnsCount={props.groupColumnsCount}
             isDetailsRowShown={isDetailsRowShown}

--- a/src/lib/Components/Table/Table.tsx
+++ b/src/lib/Components/Table/Table.tsx
@@ -42,6 +42,7 @@ export interface ITableProps {
   rowKeyField: string;
   treeGroupKeyField?: string;
   treeGroupsExpanded?: any[];
+  treeExpandButtonColumnKey?: string;
   rowReordering?: boolean;
   search?: SearchFunc;
   searchText?: string;

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -15,6 +15,7 @@ interface IRowCommonProps {
   childComponents: ChildComponents;
   columns: Column[];
   treeDeep?: number;
+  treeExpandButtonColumnKey?: string;
   dispatch: DispatchFunc;
   editableCells: EditableCell[];
   editingMode: EditingMode;
@@ -93,7 +94,7 @@ export interface IDataRowProps extends IRowCommonProps {
   validation?: ValidationFunc;
   isDetailsRowShown: boolean;
   isSelectedRow: boolean;
-  rowEditableCells: EditableCell[]
+  rowEditableCells: EditableCell[];
 }
 
 export interface IGroupRowProps {
@@ -173,6 +174,7 @@ export interface ITableBodyProps {
   selectedRows: any[];
   validation?: ValidationFunc;
   virtualScrolling?: VirtualScrolling;
+  treeExpandButtonColumnKey?: string;
 }
 
 export interface ITableFootProps extends ITableAllProps {


### PR DESCRIPTION
#262 

example: 
```
const tablePropsInit: ITableProps = {
  columns: [
    { key: 'name', title: 'Name', dataType: DataType.String },
    { key: 'productivity', title: 'Productivity', dataType: DataType.Number },
  ],
  //...
  treeExpandButtonColumnKey: 'productivity',
  //...
};
```