### PR TITLE
Make ITableProps a generic 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "8.10.1",
+  "version": "8.11.0",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/src/Demos/DetailsRowDemo/DetailsRowDemo.tsx
+++ b/src/Demos/DetailsRowDemo/DetailsRowDemo.tsx
@@ -1,6 +1,5 @@
-import { DataType, Table } from '../../lib';
+import { DataType, Table, useTableInstance } from '../../lib';
 import { ICellTextProps, IDataRowProps } from '../../lib/props';
-import { hideDetailsRow, showDetailsRow } from '../../lib/actionCreators';
 
 import React from 'react';
 
@@ -19,9 +18,10 @@ const DetailsButton: React.FC<ICellTextProps> = ({
     rowKeyValue,
     isDetailsRowShown,
 }) => {
+    const table = useTableInstance();
     return (
         <button onClick={() => {
-            dispatch(isDetailsRowShown ? hideDetailsRow(rowKeyValue) : showDetailsRow(rowKeyValue));
+            isDetailsRowShown ? table.hideDetailsRow(rowKeyValue) : table.showDetailsRow(rowKeyValue);
         }}>
             {isDetailsRowShown ? 'Hide' : 'Show'} Details Row
         </button>

--- a/src/lib/Components/Table/Table.tsx
+++ b/src/lib/Components/Table/Table.tsx
@@ -24,12 +24,12 @@ export interface ITableInstance extends ActionCreators {
     dispatch: DispatchFunc;
 }
 
-export interface ITableProps {
+export interface ITableProps<T = any> {
     columnReordering?: boolean;
     columnResizing?: boolean;
     columns: Column[];
     groupedColumns?: GroupedColumn[];
-    data?: any[];
+    data?: T[];
     detailsRows?: any[];
     editableCells?: EditableCell[];
     editingMode?: EditingMode;
@@ -71,13 +71,13 @@ export interface ITableAllProps extends ITableEvents, ITableProps {
     childComponents?: ChildComponents;
 }
 
-export interface IKaTableProps extends ITableProps {
-    childComponents?: ChildComponents;
+export interface IKaTableProps<T = any> extends ITableProps<T> {
+    childComponents?: ChildComponents<T>;
     dispatch?: DispatchFunc;
     table?: ITableInstance;
 }
 
-export const Table: React.FunctionComponent<IKaTableProps> = (props) => {
+export const Table = <T= any>(props: IKaTableProps<T>) => {
     const { dispatch } = props;
 
     return dispatch ? (

--- a/src/lib/Components/Table/Table.tsx
+++ b/src/lib/Components/Table/Table.tsx
@@ -24,12 +24,12 @@ export interface ITableInstance extends ActionCreators {
     dispatch: DispatchFunc;
 }
 
-export interface ITableProps<T = any> {
+export interface ITableProps<TData= any> {
     columnReordering?: boolean;
     columnResizing?: boolean;
     columns: Column[];
     groupedColumns?: GroupedColumn[];
-    data?: T[];
+    data?: TData[];
     detailsRows?: any[];
     editableCells?: EditableCell[];
     editingMode?: EditingMode;
@@ -71,13 +71,13 @@ export interface ITableAllProps extends ITableEvents, ITableProps {
     childComponents?: ChildComponents;
 }
 
-export interface IKaTableProps<T = any> extends ITableProps<T> {
-    childComponents?: ChildComponents<T>;
+export interface IKaTableProps<TData= any> extends ITableProps<TData> {
+    childComponents?: ChildComponents<TData>;
     dispatch?: DispatchFunc;
     table?: ITableInstance;
 }
 
-export const Table = <T= any>(props: IKaTableProps<T>) => {
+export const Table = <TData= any>(props: IKaTableProps<TData>) => {
     const { dispatch } = props;
 
     return dispatch ? (

--- a/src/lib/Models/ChildComponents.ts
+++ b/src/lib/Models/ChildComponents.ts
@@ -32,23 +32,23 @@ import {
 import { ChildComponent } from './ChildComponent';
 import { ITableProps } from '../';
 
-export class ChildComponents<T = any> {
-    public cell?: ChildComponent<ICellProps<T>>;
-    public cellEditor?: ChildComponent<ICellEditorProps<T>>;
-    public cellEditorInput?: ChildComponent<ICellEditorProps<T>>;
-    public cellText?: ChildComponent<ICellTextProps<T>>;
-    public dataRow?: ChildComponent<IDataRowProps<T>>;
-    public detailsCell?: ChildComponent<IDataRowProps<T>>;
-    public detailsRow?: ChildComponent<IDataRowProps<T>>;
+export class ChildComponents<TData= any> {
+    public cell?: ChildComponent<ICellProps<TData>>;
+    public cellEditor?: ChildComponent<ICellEditorProps<TData>>;
+    public cellEditorInput?: ChildComponent<ICellEditorProps<TData>>;
+    public cellText?: ChildComponent<ICellTextProps<TData>>;
+    public dataRow?: ChildComponent<IDataRowProps<TData>>;
+    public detailsCell?: ChildComponent<IDataRowProps<TData>>;
+    public detailsRow?: ChildComponent<IDataRowProps<TData>>;
     public emptyCell?: ChildComponent<IEmptyCellProps>;
     public filterRowCell?: ChildComponent<IFilterRowEditorProps>;
     public groupPanel?: ChildComponent<IGroupPanelProps>;
     public groupPanelCell?: ChildComponent<IGroupPanelCellProps>;
-    public groupExpandButton?: ChildComponent<IGroupRowProps<T>>;
-    public groupCell?: ChildComponent<IGroupRowProps<T>>;
-    public groupRow?: ChildComponent<IGroupRowProps<T>>;
-    public groupSummaryRow?: ChildComponent<IGroupSummaryRowProps>;
-    public groupSummaryCell?: ChildComponent<IGroupSummaryCellProps>;
+    public groupExpandButton?: ChildComponent<IGroupRowProps<TData>>;
+    public groupCell?: ChildComponent<IGroupRowProps<TData>>;
+    public groupRow?: ChildComponent<IGroupRowProps<TData>>;
+    public groupSummaryRow?: ChildComponent<IGroupSummaryRowProps<TData>>;
+    public groupSummaryCell?: ChildComponent<IGroupSummaryCellProps<TData>>;
     public headFilterButton?: ChildComponent<IHeaderFilterButtonProps>;
     public headCell?: ChildComponent<IHeadCellProps>;
     public headCellContent?: ChildComponent<IHeadCellProps>;
@@ -62,16 +62,16 @@ export class ChildComponents<T = any> {
     public pagingPages?: ChildComponent<IPagingProps>;
     public pagingSize?: ChildComponent<IPagingSizeProps>;
     public pagingSizes?: ChildComponent<IPagingProps>;
-    public popupContent?: ChildComponent<IPopupContentProps>;
+    public popupContent?: ChildComponent<IPopupContentProps<TData>>;
     public popupContentItem?: ChildComponent<IPopupContentItemProps>;
     public popupContentItemText?: ChildComponent<IPopupContentItemProps>;
-    public rootDiv?: ChildComponent<ITableProps<T>>;
+    public rootDiv?: ChildComponent<ITableProps<TData>>;
     public sortIcon?: ChildComponent<ISortIconProps>;
-    public summaryCell?: ChildComponent<ISummaryCellProps>;
-    public summaryRow?: ChildComponent<ISummaryRowProps>;
-    public table?: ChildComponent<ITableProps>;
-    public tableBody?: ChildComponent<ITableBodyProps>;
-    public tableFoot?: ChildComponent<ITableFootProps>;
+    public summaryCell?: ChildComponent<ISummaryCellProps<TData>>;
+    public summaryRow?: ChildComponent<ISummaryRowProps<TData>>;
+    public table?: ChildComponent<ITableProps<TData>>;
+    public tableBody?: ChildComponent<ITableBodyProps<TData>>;
+    public tableFoot?: ChildComponent<ITableFootProps<TData>>;
     public tableHead?: ChildComponent<ITableHeadProps>;
-    public tableWrapper?: ChildComponent<ITableProps>;
+    public tableWrapper?: ChildComponent<ITableProps<TData>>;
 }

--- a/src/lib/Models/ChildComponents.ts
+++ b/src/lib/Models/ChildComponents.ts
@@ -32,21 +32,21 @@ import {
 import { ChildComponent } from './ChildComponent';
 import { ITableProps } from '../';
 
-export class ChildComponents {
-    public cell?: ChildComponent<ICellProps>;
-    public cellEditor?: ChildComponent<ICellEditorProps>;
-    public cellEditorInput?: ChildComponent<ICellEditorProps>;
-    public cellText?: ChildComponent<ICellTextProps>;
-    public dataRow?: ChildComponent<IDataRowProps>;
-    public detailsCell?: ChildComponent<IDataRowProps>;
-    public detailsRow?: ChildComponent<IDataRowProps>;
+export class ChildComponents<T = any> {
+    public cell?: ChildComponent<ICellProps<T>>;
+    public cellEditor?: ChildComponent<ICellEditorProps<T>>;
+    public cellEditorInput?: ChildComponent<ICellEditorProps<T>>;
+    public cellText?: ChildComponent<ICellTextProps<T>>;
+    public dataRow?: ChildComponent<IDataRowProps<T>>;
+    public detailsCell?: ChildComponent<IDataRowProps<T>>;
+    public detailsRow?: ChildComponent<IDataRowProps<T>>;
     public emptyCell?: ChildComponent<IEmptyCellProps>;
     public filterRowCell?: ChildComponent<IFilterRowEditorProps>;
     public groupPanel?: ChildComponent<IGroupPanelProps>;
     public groupPanelCell?: ChildComponent<IGroupPanelCellProps>;
-    public groupExpandButton?: ChildComponent<IGroupRowProps>;
-    public groupCell?: ChildComponent<IGroupRowProps>;
-    public groupRow?: ChildComponent<IGroupRowProps>;
+    public groupExpandButton?: ChildComponent<IGroupRowProps<T>>;
+    public groupCell?: ChildComponent<IGroupRowProps<T>>;
+    public groupRow?: ChildComponent<IGroupRowProps<T>>;
     public groupSummaryRow?: ChildComponent<IGroupSummaryRowProps>;
     public groupSummaryCell?: ChildComponent<IGroupSummaryCellProps>;
     public headFilterButton?: ChildComponent<IHeaderFilterButtonProps>;
@@ -65,7 +65,7 @@ export class ChildComponents {
     public popupContent?: ChildComponent<IPopupContentProps>;
     public popupContentItem?: ChildComponent<IPopupContentItemProps>;
     public popupContentItemText?: ChildComponent<IPopupContentItemProps>;
-    public rootDiv?: ChildComponent<ITableProps>;
+    public rootDiv?: ChildComponent<ITableProps<T>>;
     public sortIcon?: ChildComponent<ISortIconProps>;
     public summaryCell?: ChildComponent<ISummaryCellProps>;
     public summaryRow?: ChildComponent<ISummaryRowProps>;

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -29,7 +29,7 @@ export interface IColGroupProps {
     groupColumnsCount: number;
 }
 
-interface IRowCommonProps {
+interface IRowCommonProps<T = any> {
     childComponents: ChildComponents;
     columns: Column[];
     treeDeep?: number;
@@ -40,13 +40,13 @@ interface IRowCommonProps {
     index?: number;
     isTreeExpanded?: boolean;
     isTreeGroup?: boolean;
-    rowData: any;
+    rowData: T;
     rowKeyField: string;
     rowKeyValue: any;
     selectedRows: any[];
 }
 
-export interface ICellProps {
+export interface ICellProps<T= any> {
     treeArrowElement?: any;
     childComponents: ChildComponents;
     column: Column;
@@ -60,7 +60,7 @@ export interface ICellProps {
     isDetailsRowShown: boolean;
     isEditableCell: boolean;
     isSelectedRow: boolean;
-    rowData: any;
+    rowData: T;
     rowKeyField: string;
     rowKeyValue: any;
     selectedRows: any[];
@@ -75,14 +75,14 @@ export interface IFilterRowEditorProps {
     dispatch: DispatchFunc;
 }
 
-export interface ICellEditorProps extends IFilterRowEditorProps {
+export interface ICellEditorProps<T= any> extends IFilterRowEditorProps {
     autoFocus?: boolean;
     editingMode: EditingMode;
     editorValue?: any;
     field: Field;
     isDetailsRowShown: boolean;
     isSelectedRow: boolean;
-    rowData: any;
+    rowData: T;
     rowKeyField: string;
     rowKeyValue: any;
     value: any;
@@ -91,7 +91,7 @@ export interface ICellEditorProps extends IFilterRowEditorProps {
     validation?: ValidationFunc;
 }
 
-export interface ICellTextProps {
+export interface ICellTextProps<T= any> {
     childComponents: ChildComponents;
     column: Column;
     dispatch: DispatchFunc;
@@ -100,14 +100,14 @@ export interface ICellTextProps {
     format?: FormatFunc;
     isDetailsRowShown: boolean;
     isSelectedRow: boolean;
-    rowData: any;
+    rowData: T;
     rowKeyField: string;
     rowKeyValue: any;
     selectedRows: any[];
     value: any;
 }
 
-export interface IDataRowProps extends IRowCommonProps {
+export interface IDataRowProps<T= any> extends IRowCommonProps<T> {
     format?: FormatFunc;
     validation?: ValidationFunc;
     isDetailsRowShown: boolean;
@@ -115,7 +115,7 @@ export interface IDataRowProps extends IRowCommonProps {
     rowEditableCells: EditableCell[];
 }
 
-export interface IGroupRowProps {
+export interface IGroupRowProps<T> {
     childComponents: ChildComponents;
     column: Column;
     columns?: Column[];
@@ -126,7 +126,7 @@ export interface IGroupRowProps {
     groupKey: any[];
     isExpanded: boolean;
     text: string;
-    groupItems?: any[];
+    groupItems?: T[];
 }
 
 export interface IGroupSummaryRowProps extends IRowsProps {

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -29,7 +29,7 @@ export interface IColGroupProps {
     groupColumnsCount: number;
 }
 
-interface IRowCommonProps<T = any> {
+interface IRowCommonProps<TData= any> {
     childComponents: ChildComponents;
     columns: Column[];
     treeDeep?: number;
@@ -40,13 +40,13 @@ interface IRowCommonProps<T = any> {
     index?: number;
     isTreeExpanded?: boolean;
     isTreeGroup?: boolean;
-    rowData: T;
+    rowData: TData;
     rowKeyField: string;
     rowKeyValue: any;
     selectedRows: any[];
 }
 
-export interface ICellProps<T= any> {
+export interface ICellProps<TData= any> {
     treeArrowElement?: any;
     childComponents: ChildComponents;
     column: Column;
@@ -60,7 +60,7 @@ export interface ICellProps<T= any> {
     isDetailsRowShown: boolean;
     isEditableCell: boolean;
     isSelectedRow: boolean;
-    rowData: T;
+    rowData: TData;
     rowKeyField: string;
     rowKeyValue: any;
     selectedRows: any[];
@@ -75,14 +75,14 @@ export interface IFilterRowEditorProps {
     dispatch: DispatchFunc;
 }
 
-export interface ICellEditorProps<T= any> extends IFilterRowEditorProps {
+export interface ICellEditorProps<TData= any> extends IFilterRowEditorProps {
     autoFocus?: boolean;
     editingMode: EditingMode;
     editorValue?: any;
     field: Field;
     isDetailsRowShown: boolean;
     isSelectedRow: boolean;
-    rowData: T;
+    rowData: TData;
     rowKeyField: string;
     rowKeyValue: any;
     value: any;
@@ -91,7 +91,7 @@ export interface ICellEditorProps<T= any> extends IFilterRowEditorProps {
     validation?: ValidationFunc;
 }
 
-export interface ICellTextProps<T= any> {
+export interface ICellTextProps<TData= any> {
     childComponents: ChildComponents;
     column: Column;
     dispatch: DispatchFunc;
@@ -100,14 +100,14 @@ export interface ICellTextProps<T= any> {
     format?: FormatFunc;
     isDetailsRowShown: boolean;
     isSelectedRow: boolean;
-    rowData: T;
+    rowData: TData;
     rowKeyField: string;
     rowKeyValue: any;
     selectedRows: any[];
     value: any;
 }
 
-export interface IDataRowProps<T= any> extends IRowCommonProps<T> {
+export interface IDataRowProps<TData= any> extends IRowCommonProps<TData> {
     format?: FormatFunc;
     validation?: ValidationFunc;
     isDetailsRowShown: boolean;
@@ -115,7 +115,7 @@ export interface IDataRowProps<T= any> extends IRowCommonProps<T> {
     rowEditableCells: EditableCell[];
 }
 
-export interface IGroupRowProps<T> {
+export interface IGroupRowProps<TData> {
     childComponents: ChildComponents;
     column: Column;
     columns?: Column[];
@@ -126,15 +126,15 @@ export interface IGroupRowProps<T> {
     groupKey: any[];
     isExpanded: boolean;
     text: string;
-    groupItems?: T[];
+    groupItems?: TData[];
 }
 
-export interface IGroupSummaryRowProps extends IRowsProps {
-    groupData: any[];
+export interface IGroupSummaryRowProps<TData= any> extends IRowsProps {
+    groupData: TData[];
     groupIndex: number;
 }
 
-export interface IGroupSummaryCellProps extends IGroupSummaryRowProps {
+export interface IGroupSummaryCellProps<TData= any> extends IGroupSummaryRowProps<TData> {
     column: Column;
 }
 
@@ -181,10 +181,10 @@ export interface ITableHeadProps {
     sortingMode: SortingMode;
 }
 
-export interface ITableBodyProps {
+export interface ITableBodyProps<TData= any> {
     childComponents: ChildComponents;
     columns: Column[];
-    data: any[];
+    data: TData[];
     loading?: ILoadingProps;
     detailsRows?: any[];
     dispatch: DispatchFunc;
@@ -204,13 +204,13 @@ export interface ITableBodyProps {
     treeExpandButtonColumnKey?: string;
 }
 
-export interface ITableFootProps extends ITableAllProps {
-    data: any[];
+export interface ITableFootProps<TData= any> extends ITableAllProps {
+    data: TData[];
     groupColumnsCount: number;
 }
-export interface ISummaryRowProps extends ITableFootProps {
+export interface ISummaryRowProps<TData= any> extends ITableFootProps<TData> {
 }
-export interface ISummaryCellProps extends ISummaryRowProps {
+export interface ISummaryCellProps<TData= any> extends ISummaryRowProps<TData> {
     column: Column;
 }
 
@@ -304,10 +304,10 @@ export interface IPagingIndexProps extends IPagingProps {
     text: any;
 }
 
-export interface IPopupContentProps {
+export interface IPopupContentProps<TData= any> {
     column: Column;
     childComponents?: ChildComponents;
-    data?: any[];
+    data?: TData[];
     dispatch: DispatchFunc;
     format?: FormatFunc;
 }

--- a/src/lib/props.ts
+++ b/src/lib/props.ts
@@ -115,7 +115,7 @@ export interface IDataRowProps<TData= any> extends IRowCommonProps<TData> {
     rowEditableCells: EditableCell[];
 }
 
-export interface IGroupRowProps<TData> {
+export interface IGroupRowProps<TData= any> {
     childComponents: ChildComponents;
     column: Column;
     columns?: Column[];


### PR DESCRIPTION
PR adds ability to specify type for table data to avoid `any` in childComponents `rowData` and Table `data`
```
const data: TableDataItem[] = [];
<Table<TableDataItem> // define data item type
    data=[data] // data has TableDataItem[] type
    //...
    childComponents={{
        cellText: {
            content: (props) => {
               //.. props.rowData has type TableDataItem 
            }
        }
    }}
}}
.../>
```

#343 