### PR TITLE
Add prevState to onDispatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-table",
-  "version": "9.2.0",
+  "version": "10.0.0",
   "license": "MIT",
   "repository": "github:komarovalexander/ka-table",
   "homepage": "https://komarovalexander.github.io/ka-table/#/overview",

--- a/src/lib/Components/CellEditorBoolean/CellEditorBoolean.test.tsx
+++ b/src/lib/Components/CellEditorBoolean/CellEditorBoolean.test.tsx
@@ -46,7 +46,6 @@ describe('CellEditorBoolean', () => {
         expect(props.dispatch).toHaveBeenCalledWith({
             columnKey: 'fieldName',
             rowKeyValue: 2,
-            oldValue: 'columnFieldValue',
             type: ActionType.UpdateCellValue,
             value: false,
         });

--- a/src/lib/Components/CellEditorBoolean/CellEditorBoolean.tsx
+++ b/src/lib/Components/CellEditorBoolean/CellEditorBoolean.tsx
@@ -23,8 +23,7 @@ const CellEditorBoolean: React.FunctionComponent<ICellEditorProps> = (props) => 
         onChange: (event) => dispatch(updateCellValue(
             rowKeyValue,
             column.key,
-            event.currentTarget.checked,
-            value)),
+            event.currentTarget.checked)),
         onBlur: () => dispatch(closeEditor(rowKeyValue, column.key))
     }, props, childComponents?.cellEditorInput);
     return (

--- a/src/lib/Components/CellEditorDate/CellEditorDate.tsx
+++ b/src/lib/Components/CellEditorDate/CellEditorDate.tsx
@@ -27,8 +27,7 @@ const CellEditorDate: React.FunctionComponent<ICellEditorProps> = (props) => {
             dispatch(updateCellValue(
                 rowKeyValue,
                 column.key,
-                newValue && new Date(newValue.getTime() + newValue.getTimezoneOffset() * 60000),
-                value
+                newValue && new Date(newValue.getTime() + newValue.getTimezoneOffset() * 60000)
             ));
         },
         onBlur: () => dispatch(closeEditor(rowKeyValue, column.key))

--- a/src/lib/Components/CellEditorNumber/CellEditorNumber.tsx
+++ b/src/lib/Components/CellEditorNumber/CellEditorNumber.tsx
@@ -24,8 +24,7 @@ const CellEditorNumber: React.FunctionComponent<ICellEditorProps> = (props) => {
             dispatch(updateCellValue(
                 rowKeyValue,
                 column.key,
-                newValue,
-                value
+                newValue
             ));
         },
         onBlur: () => {

--- a/src/lib/Components/CellEditorState/CellEditorState.tsx
+++ b/src/lib/Components/CellEditorState/CellEditorState.tsx
@@ -42,7 +42,7 @@ const CellEditorState: React.FunctionComponent<ICellEditorProps> = (props) => {
     const closeHandler = useCallback(() => {
         if (!isCellEditingMode || !validationMessage) {
             if (editorValueState !== value) {
-                dispatch(updateEditorValue(rowKeyValue, column.key, editorValueState, value));
+                dispatch(updateEditorValue(rowKeyValue, column.key, editorValueState));
             }
             if (isCellEditingMode){
                 close();

--- a/src/lib/Components/CellEditorString/CellEditorString.tsx
+++ b/src/lib/Components/CellEditorString/CellEditorString.tsx
@@ -23,8 +23,7 @@ const CellEditorString: React.FunctionComponent<ICellEditorProps> = (props) => {
             dispatch(updateCellValue(
                 rowKeyValue,
                 column.key,
-                event.currentTarget.value,
-                value
+                event.currentTarget.value
             ));
         },
         onBlur: () => {

--- a/src/lib/Components/TableUncontrolled/TableUncontrolled.tsx
+++ b/src/lib/Components/TableUncontrolled/TableUncontrolled.tsx
@@ -25,7 +25,7 @@ export const TableUncontrolled: React.FunctionComponent<ITableUncontrolledPropsK
             const nextStateDefault = kaReducer(prevState, action);
             const nextState = props.table?.customReducer ? (props.table.customReducer(nextStateDefault, action, prevState) ?? nextStateDefault) : nextStateDefault;
             setTimeout(() => {
-                props.table?.onDispatch?.(action, nextState);
+                props.table?.onDispatch?.(action, nextState, prevState);
             }, 0);
             return nextState;
         });

--- a/src/lib/Utils/CellUtils.test.ts
+++ b/src/lib/Utils/CellUtils.test.ts
@@ -87,7 +87,7 @@ describe('CellUtils', () => {
                 columnKey: 'column',
                 rowKeyValue: 1,
                 type: ActionType.UpdateCellValue,
-                value: 2
+                value: 2,
             });
         });
 

--- a/src/lib/Utils/CellUtils.ts
+++ b/src/lib/Utils/CellUtils.ts
@@ -44,7 +44,7 @@ export const addItemToEditableCells = (
 export const getCellEditorDispatchHandler = (dispatch: DispatchFunc) => {
     return (action: any) => {
         if (action.type === ActionType.UpdateEditorValue) {
-            dispatch(updateCellValue(action.rowKeyValue, action.columnKey, action.value, action.oldValue));
+            dispatch(updateCellValue(action.rowKeyValue, action.columnKey, action.value));
         } else {
             dispatch(action);
         }

--- a/src/lib/actionCreators.ts
+++ b/src/lib/actionCreators.ts
@@ -39,20 +39,18 @@ export const clearAllFilters = () => ({
     type: ActionType.ClearAllFilters,
 });
 
-export const updateEditorValue = (rowKeyValue: any, columnKey: string, value: any, oldValue?: any) => ({
+export const updateEditorValue = (rowKeyValue: any, columnKey: string, value: any) => ({
     columnKey,
     rowKeyValue,
     type: ActionType.UpdateEditorValue,
-    value,
-    oldValue // TODO: deprecate it with next major release as prevState onDispatch can be used to achieve https://github.com/komarovalexander/ka-table/issues/411
+    value
 });
 
-export const updateCellValue = (rowKeyValue: any, columnKey: string, value: any, oldValue?: any) => ({
+export const updateCellValue = (rowKeyValue: any, columnKey: string, value: any) => ({
     columnKey,
     rowKeyValue,
     type: ActionType.UpdateCellValue,
-    value,
-    oldValue // TODO: deprecate it with next major release as prevState onDispatch can be used to achieve https://github.com/komarovalexander/ka-table/issues/411
+    value
 });
 
 export const updateSortDirection = (columnKey: string) => ({

--- a/src/lib/actionCreators.ts
+++ b/src/lib/actionCreators.ts
@@ -44,7 +44,7 @@ export const updateEditorValue = (rowKeyValue: any, columnKey: string, value: an
     rowKeyValue,
     type: ActionType.UpdateEditorValue,
     value,
-    oldValue
+    oldValue // TODO: deprecate it with next major release as prevState onDispatch can be used to achieve https://github.com/komarovalexander/ka-table/issues/411
 });
 
 export const updateCellValue = (rowKeyValue: any, columnKey: string, value: any, oldValue?: any) => ({
@@ -52,7 +52,7 @@ export const updateCellValue = (rowKeyValue: any, columnKey: string, value: any,
     rowKeyValue,
     type: ActionType.UpdateCellValue,
     value,
-    oldValue
+    oldValue // TODO: deprecate it with next major release as prevState onDispatch can be used to achieve https://github.com/komarovalexander/ka-table/issues/411
 });
 
 export const updateSortDirection = (columnKey: string) => ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,7 +18,7 @@ type ElementAttributes<T> = React.AllHTMLAttributes<HTMLElement>;
 export type ChildAttributesItem<T> = WithExtraParameters<ElementAttributes<T>, T> & { ref?: any };
 export type DispatchFunc = (action: any) => void;
 export type CustomReducerFunc = (nextState: ITableProps, action: any, prevState: ITableProps) => ITableProps;
-export type OnDispatchFunc = (action: any, tableProps: ITableProps) => void;
+export type OnDispatchFunc = (action: any, tableProps: ITableProps, prevState: ITableProps) => void;
 export type ControlledPropsKeys = (keyof ITableProps)[];
 export type Field = string;
 export type FormatFunc<TData= any> = (props: { value: any, column: Column, rowData?: TData; }) => any;


### PR DESCRIPTION
`prevState` is useful when you need to get prevState of the table in `onDispatch`
```
const table = useTable({
    onDispatch: (action, tableProps, prevState) => {
    }
});
```

major version is updated as `oldValue` has been removed from `UpdateEditorValue` & `UpdateCellValue` as not required anymore (`oldValue` can be obtained from prevState)